### PR TITLE
Cdna release

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,10 +81,10 @@
     ]
   },
   "devDependencies": {
-    "@graphql-codegen/cli": "1.18.0",
-    "@graphql-codegen/typescript": "1.17.11",
-    "@graphql-codegen/typescript-operations": "1.17.8",
-    "@graphql-codegen/typescript-react-apollo": "2.0.7",
+    "@graphql-codegen/cli": "^1.21.3",
+    "@graphql-codegen/typescript": "^1.21.1",
+    "@graphql-codegen/typescript-operations": "^1.17.15",
+    "@graphql-codegen/typescript-react-apollo": "^2.2.3",
     "@tailwindcss/forms": "^0.2.1",
     "@testing-library/cypress": "^7.0.1",
     "@types/faker": "^5.1.6",

--- a/src/components/labwareScanPanel/LabwareScanPanel.tsx
+++ b/src/components/labwareScanPanel/LabwareScanPanel.tsx
@@ -1,15 +1,15 @@
-import React, { useEffect } from "react";
-import { useMachine } from "@xstate/react";
-import { Labware, LabwareLayoutFragment } from "../../types/graphql";
+import React, {useEffect} from "react";
+import {useMachine} from "@xstate/react";
+import {Labware, LabwareLayoutFragment} from "../../types/graphql";
 import Success from "../notifications/Success";
 import Warning from "../notifications/Warning";
-import { motion } from "framer-motion";
-import { Column, Row } from "react-table";
+import {motion} from "framer-motion";
+import {Column, Row} from "react-table";
 import MutedText from "../MutedText";
 import LockIcon from "../icons/LockIcon";
 import DataTable from "../DataTable";
 import ScanInput from "../ScanInput";
-import { createLabwareMachine } from "../../lib/machines/labware/labwareMachine";
+import {createLabwareMachine} from "../../lib/machines/labware/labwareMachine";
 import RemoveButton from "../buttons/RemoveButton";
 
 /**
@@ -31,14 +31,20 @@ interface LabwareScanPanelProps {
    * Lock the table. User won't be able to scan anything in, or remove anything.
    */
   locked?: boolean;
+
+  /**
+   * A function to check for problems with new labware because it is added
+   */
+  labwareCheckFunction?: ((labwares: Labware[], foundLabware: Labware) => string[]);
 }
 
 const LabwareScanPanel: React.FC<LabwareScanPanelProps> = ({
   columns,
   onChange,
   locked = false,
+  labwareCheckFunction,
 }) => {
-  const [current, send] = useMachine(createLabwareMachine());
+  const [current, send] = useMachine(createLabwareMachine([], labwareCheckFunction));
 
   // Call onChange handler whenever labwares change
   useEffect(() => {

--- a/src/components/labwareScanPanel/columns.tsx
+++ b/src/components/labwareScanPanel/columns.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { CellProps, Column } from "react-table";
-import { Labware, LabwareLayoutFragment } from "../../types/graphql";
+import {CellProps, Column} from "react-table";
+import {Labware, LabwareLayoutFragment} from "../../types/graphql";
 import LabelPrinterButton from "../LabelPrinterButton";
-import { buildLabelPrinterMachine } from "../../lib/factories/machineFactory";
+import {buildLabelPrinterMachine} from "../../lib/factories/machineFactory";
 import Circle from "../Circle";
 
 /**
@@ -22,6 +22,14 @@ const color: ColumnFactory<Map<number, any>> = (meta) => {
   };
 };
 
+function joinUnique(array: string[]) {
+  return Array.from(new Set<string>(array)).join(", ");
+}
+
+function valueFromSamples(labware: LabwareLayoutFragment, sampleFunction: (sample: any) => (string)) {
+  return joinUnique(labware.slots.flatMap(slot => slot.samples).map(sampleFunction));
+}
+
 /**
  * Barcode of the labware
  */
@@ -38,7 +46,8 @@ const barcode: ColumnFactory = () => {
 const donorId: ColumnFactory = () => {
   return {
     Header: "Donor ID",
-    accessor: (labware) => labware.slots[0]?.samples[0]?.tissue.donor.donorName,
+    accessor: (labware) =>
+        valueFromSamples(labware, (sample) => sample.tissue.donor.donorName),
   };
 };
 
@@ -49,7 +58,7 @@ const tissueType: ColumnFactory = () => {
   return {
     Header: "Tissue type",
     accessor: (labware) =>
-      labware.slots[0]?.samples[0]?.tissue.spatialLocation.tissueType.name,
+        valueFromSamples(labware, (sample) => sample.tissue.spatialLocation.tissueType.name),
   };
 };
 
@@ -60,7 +69,7 @@ const spatialLocation: ColumnFactory = () => {
   return {
     Header: "Spatial location",
     accessor: (labware) =>
-      labware.slots[0]?.samples[0]?.tissue.spatialLocation.code,
+        valueFromSamples(labware, (sample) => sample.tissue.spatialLocation.code),
   };
 };
 
@@ -70,7 +79,8 @@ const spatialLocation: ColumnFactory = () => {
 const replicate: ColumnFactory = () => {
   return {
     Header: "Replicate",
-    accessor: (labware) => labware.slots[0]?.samples[0]?.tissue.replicate,
+    accessor: (labware) =>
+    valueFromSamples(labware, (sample) => sample.tissue.replicate),
   };
 };
 
@@ -108,7 +118,16 @@ const labwareType: ColumnFactory = () => {
 const externalName: ColumnFactory = () => {
   return {
     Header: "External ID",
-    accessor: (labware) => labware.slots[0]?.samples[0]?.tissue.externalName,
+    accessor: (labware) =>
+        valueFromSamples(labware, (sample) => sample.tissue.externalName),
+  };
+};
+
+const bioState: ColumnFactory = () => {
+  return {
+    Header: "Bio state",
+    accessor: (labware) =>
+        valueFromSamples(labware, (sample) => sample.bioState.name),
   };
 };
 
@@ -122,6 +141,7 @@ const columns = {
   printer,
   labwareType,
   externalName,
+  bioState,
 };
 
 export default columns;

--- a/src/graphql/fragments/LabwareLayout.graphql
+++ b/src/graphql/fragments/LabwareLayout.graphql
@@ -27,6 +27,7 @@ fragment LabwareLayout on Labware {
                 }
                 replicate
             }
+            bioState { name }
         }
     }
 }

--- a/src/graphql/queries/FindLabware.graphql
+++ b/src/graphql/queries/FindLabware.graphql
@@ -23,6 +23,7 @@ query FindLabware($barcode: String!) {
                     }
                     replicate
                 }
+                bioState { name }
             }
         }
     }

--- a/src/graphql/queries/FindLabware.graphql
+++ b/src/graphql/queries/FindLabware.graphql
@@ -2,6 +2,9 @@ query FindLabware($barcode: String!) {
     labware(barcode: $barcode) {
         id
         barcode
+        released
+        discarded
+        destroyed
         labwareType {
             name
         }

--- a/src/graphql/queries/GetPrinters.graphql
+++ b/src/graphql/queries/GetPrinters.graphql
@@ -1,7 +1,7 @@
 query GetPrinters {
     printers {
         name
-        labelType {
+        labelTypes {
             name
         }
     }

--- a/src/lib/factories/sampleFactory.ts
+++ b/src/lib/factories/sampleFactory.ts
@@ -1,17 +1,18 @@
 import { Factory } from "fishery";
 import _ from "lodash";
 import {
-  Donor,
-  Fixative,
-  Hmdmc,
-  LifeStage,
-  Medium,
-  MouldSize,
-  Sample,
-  SpatialLocation,
-  Species,
-  Tissue,
-  TissueType,
+    BioState,
+    Donor,
+    Fixative,
+    Hmdmc,
+    LifeStage,
+    Medium,
+    MouldSize,
+    Sample,
+    SpatialLocation,
+    Species,
+    Tissue,
+    TissueType,
 } from "../../types/graphql";
 import * as faker from "faker";
 
@@ -20,6 +21,7 @@ export const sampleFactory = Factory.define<Sample>(
     id: params.id ?? sequence,
     section: params.section ?? _.random(10),
     tissue: associations.tissue ?? tissueFactory.build(),
+    bioState: associations.bioState ?? bioStateFactory.build(),
   })
 );
 
@@ -36,6 +38,12 @@ export const tissueFactory: Factory<Tissue> = Factory.define<Tissue>(
     medium: associations.medium ?? mediumFactory.build(),
     fixative: associations.fixative ?? fixativeFactory.build(),
   })
+);
+
+export const bioStateFactory: Factory<BioState> = Factory.define<BioState>(
+    ({params, sequence}) => ({
+        name: params.name ?? `BioState ${sequence}`,
+    })
 );
 
 export const fixativeFactory: Factory<Fixative> = Factory.define<Fixative>(

--- a/src/lib/machines/labelPrinter/labelPrinterMachine.ts
+++ b/src/lib/machines/labelPrinter/labelPrinterMachine.ts
@@ -30,7 +30,7 @@ export const machineOptions: Partial<MachineOptions<
 
       // Only have available printers of the labwares' label type (if there is one)
       ctx.printers = e.data.printers.filter((printer) =>
-        labwareLabelTypes.has(printer.labelType.name)
+          printer.labelTypes.some(lt => labwareLabelTypes.has(lt.name))
       );
       ctx.selectedPrinter = ctx.printers[0];
     }),

--- a/src/lib/machines/labware/labwareMachine.ts
+++ b/src/lib/machines/labware/labwareMachine.ts
@@ -1,13 +1,8 @@
-import { Machine, MachineOptions } from "xstate";
+import {Machine, MachineOptions} from "xstate";
 import * as Yup from "yup";
-import { Labware } from "../../../types/graphql";
-import {
-  LabwareContext,
-  LabwareEvents,
-  LabwareSchema,
-  State,
-} from "./labwareMachineTypes";
-import { assign } from "@xstate/immer";
+import {Labware} from "../../../types/graphql";
+import {LabwareContext, LabwareEvents, LabwareSchema, State,} from "./labwareMachineTypes";
+import {assign} from "@xstate/immer";
 import * as labwareService from "../../services/labwareService";
 
 export enum Actions {
@@ -17,6 +12,8 @@ export enum Actions {
   ASSIGN_VALIDATION_ERROR = "assignValidationError",
   ASSIGN_FOUND_LABWARE = "assignFoundLabware",
   ASSIGN_FIND_LABWARE_ERROR = "assignFindLabwareError",
+  ADD_FOUND_LABWARE = "addFoundLabware",
+  FOUND_LABWARE_CHECK_ERROR = "foundLabwareCheckError",
 }
 
 export enum Activities {}
@@ -30,6 +27,7 @@ export enum Guards {
 export enum Services {
   VALIDATE_BARCODE = "validateBarcode",
   FIND_LABWARE_BY_BARCODE = "findLabwareByBarcode",
+  VALIDATE_FOUND_LABWARE = "validateFoundLabware",
 }
 
 export const labwareMachineOptions: Partial<MachineOptions<
@@ -70,8 +68,23 @@ export const labwareMachineOptions: Partial<MachineOptions<
       if (e.type !== "done.invoke.findLabware") {
         return;
       }
-      ctx.labwares.push(e.data);
+      ctx.foundLabware = e.data
       ctx.currentBarcode = "";
+    }),
+
+    [Actions.ADD_FOUND_LABWARE]: assign((ctx, e) => {
+      if (e.type !== "done.invoke.validateFoundLabware") {
+        return;
+      }
+      ctx.labwares.push(e.data);
+      ctx.foundLabware = null;
+    }),
+
+    [Actions.FOUND_LABWARE_CHECK_ERROR]: assign((ctx, e) => {
+      if (e.type !== "error.platform.validateFoundLabware") {
+        return;
+      }
+      ctx.errorMessage = e.data.join("\n");
     }),
 
     [Actions.ASSIGN_FIND_LABWARE_ERROR]: assign((ctx, e) => {
@@ -96,6 +109,16 @@ export const labwareMachineOptions: Partial<MachineOptions<
       labwareService.findLabwareByBarcode(ctx.currentBarcode),
     [Services.VALIDATE_BARCODE]: (ctx: LabwareContext) =>
       ctx.validator.validate(ctx.currentBarcode),
+    [Services.VALIDATE_FOUND_LABWARE]: (ctx: LabwareContext) => {
+      return new Promise((resolve, reject) => {
+        const problems = ctx.foundLabware ? ctx.foundLabwareCheck(ctx.labwares, ctx.foundLabware) : ["Labware not loaded."];
+        if (problems.length === 0) {
+          resolve(ctx.foundLabware);
+        } else {
+          reject(problems);
+        }
+      });
+    }
   },
 };
 
@@ -115,12 +138,14 @@ export const labwareMachineOptions: Partial<MachineOptions<
  *   Object.assign({}, labwareMachine.context, { validator: Yup.string().min(3).required("Barcode is required") })
  * )
  */
-export const createLabwareMachine = (labwares: Labware[] = []) =>
+export const createLabwareMachine = (labwares: Labware[] = [], foundLabwareCheck?: ((labwares: Labware[], foundLabware: Labware) => string[])) =>
   Machine<LabwareContext, LabwareSchema, LabwareEvents>(
     {
       context: {
         currentBarcode: "",
+        foundLabware: null,
         labwares,
+        foundLabwareCheck: (foundLabwareCheck ?? (() => [])),
         validator: Yup.string().trim().required("Barcode is required"),
         successMessage: null,
         errorMessage: null,
@@ -180,7 +205,7 @@ export const createLabwareMachine = (labwares: Labware[] = []) =>
             id: "findLabware",
             src: Services.FIND_LABWARE_BY_BARCODE,
             onDone: {
-              target: State.NORMAL_FQ,
+              target: State.VALIDATING_FOUND_LABWARE,
               actions: [Actions.ASSIGN_FOUND_LABWARE],
             },
             onError: {
@@ -189,6 +214,20 @@ export const createLabwareMachine = (labwares: Labware[] = []) =>
             },
           },
         },
+        [State.VALIDATING_FOUND_LABWARE]: {
+          invoke: {
+            id: "validateFoundLabware",
+            src: Services.VALIDATE_FOUND_LABWARE,
+            onDone: {
+              target: State.NORMAL_FQ,
+              actions: [Actions.ADD_FOUND_LABWARE],
+            },
+            onError: {
+              target: State.ERROR_FQ,
+              actions: [Actions.FOUND_LABWARE_CHECK_ERROR],
+            }
+          }
+        }
       },
     },
     labwareMachineOptions

--- a/src/lib/presentationModels/slideRegistrationPresentationModel.ts
+++ b/src/lib/presentationModels/slideRegistrationPresentationModel.ts
@@ -138,7 +138,7 @@ export default class SlideRegistrationPresentationModel extends MachinePresentat
                     species: validation.species,
                     hmdmc: validation.hmdmc,
                     tissueType: validation.tissueType,
-                    sectionExternalIdentifier:
+                    externalIdentifier:
                       validation.sectionExternalIdentifier,
                     spatialLocation: validation.spatialLocation,
                     replicateNumber: validation.replicateNumber,

--- a/src/mocks/handlers/labwareHandlers.ts
+++ b/src/mocks/handlers/labwareHandlers.ts
@@ -36,6 +36,9 @@ const labwareHandlers = [
             samples: [
               {
                 id: Math.ceil(Math.random() * 1000),
+                bioState: {
+                  name: "bs",
+                },
                 tissue: {
                   replicate: 5,
                   externalName: "EXT 1",

--- a/src/mocks/handlers/printHandlers.ts
+++ b/src/mocks/handlers/printHandlers.ts
@@ -11,16 +11,16 @@ const printers = labwareTypeInstances.reduce<GetPrintersQuery["printers"]>(
   (memo, labwareType) => {
     if (labwareType.labelType?.name) {
       memo.push({
-        labelType: {
+        labelTypes: [{
           name: labwareType.labelType.name,
-        },
+        }],
         name: `${labwareType.name} Printer`,
       });
 
       memo.push({
-        labelType: {
+        labelTypes: [{
           name: labwareType.labelType.name,
-        },
+        }],
         name: `${labwareType.name} Printer 2`,
       });
     }

--- a/src/mocks/handlers/registrationHandlers.ts
+++ b/src/mocks/handlers/registrationHandlers.ts
@@ -1,5 +1,5 @@
-import { graphql } from "msw";
-import { uniqueId } from "lodash";
+import {graphql} from "msw";
+import {uniqueId} from "lodash";
 import {
   GetRegistrationInfoQuery,
   GetRegistrationInfoQueryVariables,
@@ -153,6 +153,7 @@ const registrationHandlers = [
                             },
                           },
                         },
+                        bioState: { name: "Tissue" },
                       },
                     ],
                   },
@@ -201,6 +202,7 @@ const registrationHandlers = [
                           donorName: content.donorIdentifier,
                         },
                       },
+                      bioState: { name:"Tissue" }
                     },
                   ],
                 })),

--- a/src/pages/registration/SlideRegistrationForm.tsx
+++ b/src/pages/registration/SlideRegistrationForm.tsx
@@ -467,7 +467,7 @@ const SlotForm: React.FC<SlotFormParams> = ({
 
       <FormikInput
         label="Section External Identifier"
-        name={`labwares.${currentIndex}.slots.${slotAddress}.sectionExternalIdentifier`}
+        name={`labwares.${currentIndex}.slots.${slotAddress}.externalIdentifier`}
       />
 
       <FormikInput

--- a/src/pages/release/ReleaseForm.tsx
+++ b/src/pages/release/ReleaseForm.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect } from "react";
-import GrayBox, { Sidebar } from "../../components/layouts/GrayBox";
-import { motion } from "framer-motion";
+import React, {useEffect} from "react";
+import GrayBox, {Sidebar} from "../../components/layouts/GrayBox";
+import {motion} from "framer-motion";
 import variants from "../../lib/motionVariants";
 import Heading from "../../components/Heading";
 import MutedText from "../../components/MutedText";
@@ -8,12 +8,12 @@ import LabwareScanPanel from "../../components/labwareScanPanel/LabwareScanPanel
 import columns from "../../components/labwareScanPanel/columns";
 import FormikSelect from "../../components/forms/Select";
 import PinkButton from "../../components/buttons/PinkButton";
-import { Form, FormikProps } from "formik";
-import { Labware, ReleaseRequest } from "../../types/graphql";
-import { FormikErrorMessage } from "../../components/forms";
+import {Form, FormikProps} from "formik";
+import {Labware, ReleaseRequest} from "../../types/graphql";
+import {FormikErrorMessage} from "../../components/forms";
 import ReleasePresentationModel from "../../lib/presentationModels/releasePresentationModel";
 import Warning from "../../components/notifications/Warning";
-import { toast } from "react-toastify";
+import {toast} from "react-toastify";
 import Success from "../../components/notifications/Success";
 import WhiteButton from "../../components/buttons/WhiteButton";
 import DownloadIcon from "../../components/icons/DownloadIcon";
@@ -74,6 +74,7 @@ const ReleaseForm: React.FC<ReleaseFormProps> = ({ model, formik }) => {
                 columns.donorId(),
                 columns.labwareType(),
                 columns.externalName(),
+                columns.bioState(),
               ]}
               onChange={onScanPanelChange}
             />

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -1,5 +1,6 @@
-import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
+import {gql} from '@apollo/client';
+
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
@@ -634,6 +635,9 @@ export type LabwareLayoutFragment = (
             & Pick<TissueType, 'name'>
           ) }
         ) }
+      ), bioState: (
+        { __typename?: 'BioState' }
+        & Pick<BioState, 'name'>
       ) }
     )> }
   )> }
@@ -1039,6 +1043,9 @@ export type FindLabwareQuery = (
               & Pick<TissueType, 'name'>
             ) }
           ) }
+        ), bioState: (
+          { __typename?: 'BioState' }
+          & Pick<BioState, 'name'>
         ) }
       )> }
     )> }
@@ -1201,6 +1208,9 @@ export const LabwareLayoutFragmentDoc = gql`
           code
         }
         replicate
+      }
+      bioState {
+        name
       }
     }
   }
@@ -1926,6 +1936,9 @@ export const FindLabwareDocument = gql`
             code
           }
           replicate
+        }
+        bioState {
+          name
         }
       }
     }

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -1019,7 +1019,7 @@ export type FindLabwareQuery = (
   { __typename?: 'Query' }
   & { labware: (
     { __typename?: 'Labware' }
-    & Pick<Labware, 'id' | 'barcode'>
+    & Pick<Labware, 'id' | 'barcode' | 'released' | 'discarded' | 'destroyed'>
     & { labwareType: (
       { __typename?: 'LabwareType' }
       & Pick<LabwareType, 'name'>
@@ -1916,6 +1916,9 @@ export const FindLabwareDocument = gql`
   labware(barcode: $barcode) {
     id
     barcode
+    released
+    discarded
+    destroyed
     labwareType {
       name
     }

--- a/src/types/graphql.tsx
+++ b/src/types/graphql.tsx
@@ -2,6 +2,9 @@ import { gql } from '@apollo/client';
 import * as Apollo from '@apollo/client';
 export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+const defaultOptions =  {}
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;
@@ -84,6 +87,11 @@ export type Donor = {
   species: Species;
 };
 
+export type BioState = {
+  __typename?: 'BioState';
+  name: Scalars['String'];
+};
+
 export type Tissue = {
   __typename?: 'Tissue';
   externalName: Scalars['String'];
@@ -101,6 +109,7 @@ export type Sample = {
   id: Scalars['Int'];
   section?: Maybe<Scalars['Int']>;
   tissue: Tissue;
+  bioState: BioState;
 };
 
 export type Slot = {
@@ -246,6 +255,18 @@ export type ConfirmOperationRequest = {
   labware: Array<ConfirmOperationLabware>;
 };
 
+export type SlotCopyContent = {
+  sourceBarcode: Scalars['String'];
+  sourceAddress: Scalars['Address'];
+  destinationAddress: Scalars['Address'];
+};
+
+export type SlotCopyRequest = {
+  labwareType: Scalars['String'];
+  operationType: Scalars['String'];
+  contents: Array<SlotCopyContent>;
+};
+
 export type Action = {
   __typename?: 'Action';
   source: Slot;
@@ -278,7 +299,7 @@ export type PlanResult = {
 export type Printer = {
   __typename?: 'Printer';
   name: Scalars['String'];
-  labelType: LabelType;
+  labelTypes: Array<LabelType>;
 };
 
 export type Comment = {
@@ -501,6 +522,7 @@ export type Mutation = {
   release: ReleaseResult;
   extract: OperationResult;
   destroy: DestroyResult;
+  slotCopy: OperationResult;
   storeBarcode: StoredItem;
   unstoreBarcode?: Maybe<UnstoredItem>;
   empty: UnstoreResult;
@@ -552,6 +574,11 @@ export type MutationExtractArgs = {
 
 export type MutationDestroyArgs = {
   request: DestroyRequest;
+};
+
+
+export type MutationSlotCopyArgs = {
+  request: SlotCopyRequest;
 };
 
 
@@ -1066,10 +1093,10 @@ export type GetPrintersQuery = (
   & { printers: Array<(
     { __typename?: 'Printer' }
     & Pick<Printer, 'name'>
-    & { labelType: (
+    & { labelTypes: Array<(
       { __typename?: 'LabelType' }
       & Pick<LabelType, 'name'>
-    ) }
+    )> }
   )> }
 );
 
@@ -1245,7 +1272,8 @@ export type ConfirmMutationFn = Apollo.MutationFunction<ConfirmMutation, Confirm
  * });
  */
 export function useConfirmMutation(baseOptions?: Apollo.MutationHookOptions<ConfirmMutation, ConfirmMutationVariables>) {
-        return Apollo.useMutation<ConfirmMutation, ConfirmMutationVariables>(ConfirmDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ConfirmMutation, ConfirmMutationVariables>(ConfirmDocument, options);
       }
 export type ConfirmMutationHookResult = ReturnType<typeof useConfirmMutation>;
 export type ConfirmMutationResult = Apollo.MutationResult<ConfirmMutation>;
@@ -1281,7 +1309,8 @@ export type DestroyMutationFn = Apollo.MutationFunction<DestroyMutation, Destroy
  * });
  */
 export function useDestroyMutation(baseOptions?: Apollo.MutationHookOptions<DestroyMutation, DestroyMutationVariables>) {
-        return Apollo.useMutation<DestroyMutation, DestroyMutationVariables>(DestroyDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<DestroyMutation, DestroyMutationVariables>(DestroyDocument, options);
       }
 export type DestroyMutationHookResult = ReturnType<typeof useDestroyMutation>;
 export type DestroyMutationResult = Apollo.MutationResult<DestroyMutation>;
@@ -1313,7 +1342,8 @@ export type EmptyLocationMutationFn = Apollo.MutationFunction<EmptyLocationMutat
  * });
  */
 export function useEmptyLocationMutation(baseOptions?: Apollo.MutationHookOptions<EmptyLocationMutation, EmptyLocationMutationVariables>) {
-        return Apollo.useMutation<EmptyLocationMutation, EmptyLocationMutationVariables>(EmptyLocationDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<EmptyLocationMutation, EmptyLocationMutationVariables>(EmptyLocationDocument, options);
       }
 export type EmptyLocationMutationHookResult = ReturnType<typeof useEmptyLocationMutation>;
 export type EmptyLocationMutationResult = Apollo.MutationResult<EmptyLocationMutation>;
@@ -1368,7 +1398,8 @@ export type ExtractMutationFn = Apollo.MutationFunction<ExtractMutation, Extract
  * });
  */
 export function useExtractMutation(baseOptions?: Apollo.MutationHookOptions<ExtractMutation, ExtractMutationVariables>) {
-        return Apollo.useMutation<ExtractMutation, ExtractMutationVariables>(ExtractDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ExtractMutation, ExtractMutationVariables>(ExtractDocument, options);
       }
 export type ExtractMutationHookResult = ReturnType<typeof useExtractMutation>;
 export type ExtractMutationResult = Apollo.MutationResult<ExtractMutation>;
@@ -1403,7 +1434,8 @@ export type LoginMutationFn = Apollo.MutationFunction<LoginMutation, LoginMutati
  * });
  */
 export function useLoginMutation(baseOptions?: Apollo.MutationHookOptions<LoginMutation, LoginMutationVariables>) {
-        return Apollo.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<LoginMutation, LoginMutationVariables>(LoginDocument, options);
       }
 export type LoginMutationHookResult = ReturnType<typeof useLoginMutation>;
 export type LoginMutationResult = Apollo.MutationResult<LoginMutation>;
@@ -1432,7 +1464,8 @@ export type LogoutMutationFn = Apollo.MutationFunction<LogoutMutation, LogoutMut
  * });
  */
 export function useLogoutMutation(baseOptions?: Apollo.MutationHookOptions<LogoutMutation, LogoutMutationVariables>) {
-        return Apollo.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<LogoutMutation, LogoutMutationVariables>(LogoutDocument, options);
       }
 export type LogoutMutationHookResult = ReturnType<typeof useLogoutMutation>;
 export type LogoutMutationResult = Apollo.MutationResult<LogoutMutation>;
@@ -1488,7 +1521,8 @@ export type PlanMutationFn = Apollo.MutationFunction<PlanMutation, PlanMutationV
  * });
  */
 export function usePlanMutation(baseOptions?: Apollo.MutationHookOptions<PlanMutation, PlanMutationVariables>) {
-        return Apollo.useMutation<PlanMutation, PlanMutationVariables>(PlanDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<PlanMutation, PlanMutationVariables>(PlanDocument, options);
       }
 export type PlanMutationHookResult = ReturnType<typeof usePlanMutation>;
 export type PlanMutationResult = Apollo.MutationResult<PlanMutation>;
@@ -1519,7 +1553,8 @@ export type PrintMutationFn = Apollo.MutationFunction<PrintMutation, PrintMutati
  * });
  */
 export function usePrintMutation(baseOptions?: Apollo.MutationHookOptions<PrintMutation, PrintMutationVariables>) {
-        return Apollo.useMutation<PrintMutation, PrintMutationVariables>(PrintDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<PrintMutation, PrintMutationVariables>(PrintDocument, options);
       }
 export type PrintMutationHookResult = ReturnType<typeof usePrintMutation>;
 export type PrintMutationResult = Apollo.MutationResult<PrintMutation>;
@@ -1553,7 +1588,8 @@ export type RegisterSectionsMutationFn = Apollo.MutationFunction<RegisterSection
  * });
  */
 export function useRegisterSectionsMutation(baseOptions?: Apollo.MutationHookOptions<RegisterSectionsMutation, RegisterSectionsMutationVariables>) {
-        return Apollo.useMutation<RegisterSectionsMutation, RegisterSectionsMutationVariables>(RegisterSectionsDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RegisterSectionsMutation, RegisterSectionsMutationVariables>(RegisterSectionsDocument, options);
       }
 export type RegisterSectionsMutationHookResult = ReturnType<typeof useRegisterSectionsMutation>;
 export type RegisterSectionsMutationResult = Apollo.MutationResult<RegisterSectionsMutation>;
@@ -1598,7 +1634,8 @@ export type RegisterTissuesMutationFn = Apollo.MutationFunction<RegisterTissuesM
  * });
  */
 export function useRegisterTissuesMutation(baseOptions?: Apollo.MutationHookOptions<RegisterTissuesMutation, RegisterTissuesMutationVariables>) {
-        return Apollo.useMutation<RegisterTissuesMutation, RegisterTissuesMutationVariables>(RegisterTissuesDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RegisterTissuesMutation, RegisterTissuesMutationVariables>(RegisterTissuesDocument, options);
       }
 export type RegisterTissuesMutationHookResult = ReturnType<typeof useRegisterTissuesMutation>;
 export type RegisterTissuesMutationResult = Apollo.MutationResult<RegisterTissuesMutation>;
@@ -1641,7 +1678,8 @@ export type ReleaseLabwareMutationFn = Apollo.MutationFunction<ReleaseLabwareMut
  * });
  */
 export function useReleaseLabwareMutation(baseOptions?: Apollo.MutationHookOptions<ReleaseLabwareMutation, ReleaseLabwareMutationVariables>) {
-        return Apollo.useMutation<ReleaseLabwareMutation, ReleaseLabwareMutationVariables>(ReleaseLabwareDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<ReleaseLabwareMutation, ReleaseLabwareMutationVariables>(ReleaseLabwareDocument, options);
       }
 export type ReleaseLabwareMutationHookResult = ReturnType<typeof useReleaseLabwareMutation>;
 export type ReleaseLabwareMutationResult = Apollo.MutationResult<ReleaseLabwareMutation>;
@@ -1674,7 +1712,8 @@ export type SetLocationCustomNameMutationFn = Apollo.MutationFunction<SetLocatio
  * });
  */
 export function useSetLocationCustomNameMutation(baseOptions?: Apollo.MutationHookOptions<SetLocationCustomNameMutation, SetLocationCustomNameMutationVariables>) {
-        return Apollo.useMutation<SetLocationCustomNameMutation, SetLocationCustomNameMutationVariables>(SetLocationCustomNameDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<SetLocationCustomNameMutation, SetLocationCustomNameMutationVariables>(SetLocationCustomNameDocument, options);
       }
 export type SetLocationCustomNameMutationHookResult = ReturnType<typeof useSetLocationCustomNameMutation>;
 export type SetLocationCustomNameMutationResult = Apollo.MutationResult<SetLocationCustomNameMutation>;
@@ -1710,7 +1749,8 @@ export type StoreBarcodeMutationFn = Apollo.MutationFunction<StoreBarcodeMutatio
  * });
  */
 export function useStoreBarcodeMutation(baseOptions?: Apollo.MutationHookOptions<StoreBarcodeMutation, StoreBarcodeMutationVariables>) {
-        return Apollo.useMutation<StoreBarcodeMutation, StoreBarcodeMutationVariables>(StoreBarcodeDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<StoreBarcodeMutation, StoreBarcodeMutationVariables>(StoreBarcodeDocument, options);
       }
 export type StoreBarcodeMutationHookResult = ReturnType<typeof useStoreBarcodeMutation>;
 export type StoreBarcodeMutationResult = Apollo.MutationResult<StoreBarcodeMutation>;
@@ -1743,7 +1783,8 @@ export type UnstoreBarcodeMutationFn = Apollo.MutationFunction<UnstoreBarcodeMut
  * });
  */
 export function useUnstoreBarcodeMutation(baseOptions?: Apollo.MutationHookOptions<UnstoreBarcodeMutation, UnstoreBarcodeMutationVariables>) {
-        return Apollo.useMutation<UnstoreBarcodeMutation, UnstoreBarcodeMutationVariables>(UnstoreBarcodeDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UnstoreBarcodeMutation, UnstoreBarcodeMutationVariables>(UnstoreBarcodeDocument, options);
       }
 export type UnstoreBarcodeMutationHookResult = ReturnType<typeof useUnstoreBarcodeMutation>;
 export type UnstoreBarcodeMutationResult = Apollo.MutationResult<UnstoreBarcodeMutation>;
@@ -1772,10 +1813,12 @@ export const CurrentUserDocument = gql`
  * });
  */
 export function useCurrentUserQuery(baseOptions?: Apollo.QueryHookOptions<CurrentUserQuery, CurrentUserQueryVariables>) {
-        return Apollo.useQuery<CurrentUserQuery, CurrentUserQueryVariables>(CurrentUserDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<CurrentUserQuery, CurrentUserQueryVariables>(CurrentUserDocument, options);
       }
 export function useCurrentUserLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<CurrentUserQuery, CurrentUserQueryVariables>) {
-          return Apollo.useLazyQuery<CurrentUserQuery, CurrentUserQueryVariables>(CurrentUserDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<CurrentUserQuery, CurrentUserQueryVariables>(CurrentUserDocument, options);
         }
 export type CurrentUserQueryHookResult = ReturnType<typeof useCurrentUserQuery>;
 export type CurrentUserLazyQueryHookResult = ReturnType<typeof useCurrentUserLazyQuery>;
@@ -1847,11 +1890,13 @@ export const FindDocument = gql`
  *   },
  * });
  */
-export function useFindQuery(baseOptions?: Apollo.QueryHookOptions<FindQuery, FindQueryVariables>) {
-        return Apollo.useQuery<FindQuery, FindQueryVariables>(FindDocument, baseOptions);
+export function useFindQuery(baseOptions: Apollo.QueryHookOptions<FindQuery, FindQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FindQuery, FindQueryVariables>(FindDocument, options);
       }
 export function useFindLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FindQuery, FindQueryVariables>) {
-          return Apollo.useLazyQuery<FindQuery, FindQueryVariables>(FindDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FindQuery, FindQueryVariables>(FindDocument, options);
         }
 export type FindQueryHookResult = ReturnType<typeof useFindQuery>;
 export type FindLazyQueryHookResult = ReturnType<typeof useFindLazyQuery>;
@@ -1904,11 +1949,13 @@ export const FindLabwareDocument = gql`
  *   },
  * });
  */
-export function useFindLabwareQuery(baseOptions?: Apollo.QueryHookOptions<FindLabwareQuery, FindLabwareQueryVariables>) {
-        return Apollo.useQuery<FindLabwareQuery, FindLabwareQueryVariables>(FindLabwareDocument, baseOptions);
+export function useFindLabwareQuery(baseOptions: Apollo.QueryHookOptions<FindLabwareQuery, FindLabwareQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FindLabwareQuery, FindLabwareQueryVariables>(FindLabwareDocument, options);
       }
 export function useFindLabwareLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FindLabwareQuery, FindLabwareQueryVariables>) {
-          return Apollo.useLazyQuery<FindLabwareQuery, FindLabwareQueryVariables>(FindLabwareDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FindLabwareQuery, FindLabwareQueryVariables>(FindLabwareDocument, options);
         }
 export type FindLabwareQueryHookResult = ReturnType<typeof useFindLabwareQuery>;
 export type FindLabwareLazyQueryHookResult = ReturnType<typeof useFindLabwareLazyQuery>;
@@ -1939,11 +1986,13 @@ export const FindLabwareLocationDocument = gql`
  *   },
  * });
  */
-export function useFindLabwareLocationQuery(baseOptions?: Apollo.QueryHookOptions<FindLabwareLocationQuery, FindLabwareLocationQueryVariables>) {
-        return Apollo.useQuery<FindLabwareLocationQuery, FindLabwareLocationQueryVariables>(FindLabwareLocationDocument, baseOptions);
+export function useFindLabwareLocationQuery(baseOptions: Apollo.QueryHookOptions<FindLabwareLocationQuery, FindLabwareLocationQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FindLabwareLocationQuery, FindLabwareLocationQueryVariables>(FindLabwareLocationDocument, options);
       }
 export function useFindLabwareLocationLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FindLabwareLocationQuery, FindLabwareLocationQueryVariables>) {
-          return Apollo.useLazyQuery<FindLabwareLocationQuery, FindLabwareLocationQueryVariables>(FindLabwareLocationDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FindLabwareLocationQuery, FindLabwareLocationQueryVariables>(FindLabwareLocationDocument, options);
         }
 export type FindLabwareLocationQueryHookResult = ReturnType<typeof useFindLabwareLocationQuery>;
 export type FindLabwareLocationLazyQueryHookResult = ReturnType<typeof useFindLabwareLocationLazyQuery>;
@@ -1972,11 +2021,13 @@ export const FindLocationByBarcodeDocument = gql`
  *   },
  * });
  */
-export function useFindLocationByBarcodeQuery(baseOptions?: Apollo.QueryHookOptions<FindLocationByBarcodeQuery, FindLocationByBarcodeQueryVariables>) {
-        return Apollo.useQuery<FindLocationByBarcodeQuery, FindLocationByBarcodeQueryVariables>(FindLocationByBarcodeDocument, baseOptions);
+export function useFindLocationByBarcodeQuery(baseOptions: Apollo.QueryHookOptions<FindLocationByBarcodeQuery, FindLocationByBarcodeQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<FindLocationByBarcodeQuery, FindLocationByBarcodeQueryVariables>(FindLocationByBarcodeDocument, options);
       }
 export function useFindLocationByBarcodeLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<FindLocationByBarcodeQuery, FindLocationByBarcodeQueryVariables>) {
-          return Apollo.useLazyQuery<FindLocationByBarcodeQuery, FindLocationByBarcodeQueryVariables>(FindLocationByBarcodeDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<FindLocationByBarcodeQuery, FindLocationByBarcodeQueryVariables>(FindLocationByBarcodeDocument, options);
         }
 export type FindLocationByBarcodeQueryHookResult = ReturnType<typeof useFindLocationByBarcodeQuery>;
 export type FindLocationByBarcodeLazyQueryHookResult = ReturnType<typeof useFindLocationByBarcodeLazyQuery>;
@@ -2006,10 +2057,12 @@ export const GetDestroyInfoDocument = gql`
  * });
  */
 export function useGetDestroyInfoQuery(baseOptions?: Apollo.QueryHookOptions<GetDestroyInfoQuery, GetDestroyInfoQueryVariables>) {
-        return Apollo.useQuery<GetDestroyInfoQuery, GetDestroyInfoQueryVariables>(GetDestroyInfoDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetDestroyInfoQuery, GetDestroyInfoQueryVariables>(GetDestroyInfoDocument, options);
       }
 export function useGetDestroyInfoLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetDestroyInfoQuery, GetDestroyInfoQueryVariables>) {
-          return Apollo.useLazyQuery<GetDestroyInfoQuery, GetDestroyInfoQueryVariables>(GetDestroyInfoDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetDestroyInfoQuery, GetDestroyInfoQueryVariables>(GetDestroyInfoDocument, options);
         }
 export type GetDestroyInfoQueryHookResult = ReturnType<typeof useGetDestroyInfoQuery>;
 export type GetDestroyInfoLazyQueryHookResult = ReturnType<typeof useGetDestroyInfoLazyQuery>;
@@ -2018,7 +2071,7 @@ export const GetPrintersDocument = gql`
     query GetPrinters {
   printers {
     name
-    labelType {
+    labelTypes {
       name
     }
   }
@@ -2041,10 +2094,12 @@ export const GetPrintersDocument = gql`
  * });
  */
 export function useGetPrintersQuery(baseOptions?: Apollo.QueryHookOptions<GetPrintersQuery, GetPrintersQueryVariables>) {
-        return Apollo.useQuery<GetPrintersQuery, GetPrintersQueryVariables>(GetPrintersDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetPrintersQuery, GetPrintersQueryVariables>(GetPrintersDocument, options);
       }
 export function useGetPrintersLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetPrintersQuery, GetPrintersQueryVariables>) {
-          return Apollo.useLazyQuery<GetPrintersQuery, GetPrintersQueryVariables>(GetPrintersDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetPrintersQuery, GetPrintersQueryVariables>(GetPrintersDocument, options);
         }
 export type GetPrintersQueryHookResult = ReturnType<typeof useGetPrintersQuery>;
 export type GetPrintersLazyQueryHookResult = ReturnType<typeof useGetPrintersLazyQuery>;
@@ -2095,10 +2150,12 @@ export const GetRegistrationInfoDocument = gql`
  * });
  */
 export function useGetRegistrationInfoQuery(baseOptions?: Apollo.QueryHookOptions<GetRegistrationInfoQuery, GetRegistrationInfoQueryVariables>) {
-        return Apollo.useQuery<GetRegistrationInfoQuery, GetRegistrationInfoQueryVariables>(GetRegistrationInfoDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetRegistrationInfoQuery, GetRegistrationInfoQueryVariables>(GetRegistrationInfoDocument, options);
       }
 export function useGetRegistrationInfoLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetRegistrationInfoQuery, GetRegistrationInfoQueryVariables>) {
-          return Apollo.useLazyQuery<GetRegistrationInfoQuery, GetRegistrationInfoQueryVariables>(GetRegistrationInfoDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetRegistrationInfoQuery, GetRegistrationInfoQueryVariables>(GetRegistrationInfoDocument, options);
         }
 export type GetRegistrationInfoQueryHookResult = ReturnType<typeof useGetRegistrationInfoQuery>;
 export type GetRegistrationInfoLazyQueryHookResult = ReturnType<typeof useGetRegistrationInfoLazyQuery>;
@@ -2130,10 +2187,12 @@ export const GetReleaseInfoDocument = gql`
  * });
  */
 export function useGetReleaseInfoQuery(baseOptions?: Apollo.QueryHookOptions<GetReleaseInfoQuery, GetReleaseInfoQueryVariables>) {
-        return Apollo.useQuery<GetReleaseInfoQuery, GetReleaseInfoQueryVariables>(GetReleaseInfoDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetReleaseInfoQuery, GetReleaseInfoQueryVariables>(GetReleaseInfoDocument, options);
       }
 export function useGetReleaseInfoLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetReleaseInfoQuery, GetReleaseInfoQueryVariables>) {
-          return Apollo.useLazyQuery<GetReleaseInfoQuery, GetReleaseInfoQueryVariables>(GetReleaseInfoDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetReleaseInfoQuery, GetReleaseInfoQueryVariables>(GetReleaseInfoDocument, options);
         }
 export type GetReleaseInfoQueryHookResult = ReturnType<typeof useGetReleaseInfoQuery>;
 export type GetReleaseInfoLazyQueryHookResult = ReturnType<typeof useGetReleaseInfoLazyQuery>;
@@ -2162,10 +2221,12 @@ export const GetSearchInfoDocument = gql`
  * });
  */
 export function useGetSearchInfoQuery(baseOptions?: Apollo.QueryHookOptions<GetSearchInfoQuery, GetSearchInfoQueryVariables>) {
-        return Apollo.useQuery<GetSearchInfoQuery, GetSearchInfoQueryVariables>(GetSearchInfoDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetSearchInfoQuery, GetSearchInfoQueryVariables>(GetSearchInfoDocument, options);
       }
 export function useGetSearchInfoLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetSearchInfoQuery, GetSearchInfoQueryVariables>) {
-          return Apollo.useLazyQuery<GetSearchInfoQuery, GetSearchInfoQueryVariables>(GetSearchInfoDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetSearchInfoQuery, GetSearchInfoQueryVariables>(GetSearchInfoDocument, options);
         }
 export type GetSearchInfoQueryHookResult = ReturnType<typeof useGetSearchInfoQuery>;
 export type GetSearchInfoLazyQueryHookResult = ReturnType<typeof useGetSearchInfoLazyQuery>;
@@ -2201,10 +2262,12 @@ export const GetSectioningInfoDocument = gql`
  * });
  */
 export function useGetSectioningInfoQuery(baseOptions?: Apollo.QueryHookOptions<GetSectioningInfoQuery, GetSectioningInfoQueryVariables>) {
-        return Apollo.useQuery<GetSectioningInfoQuery, GetSectioningInfoQueryVariables>(GetSectioningInfoDocument, baseOptions);
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetSectioningInfoQuery, GetSectioningInfoQueryVariables>(GetSectioningInfoDocument, options);
       }
 export function useGetSectioningInfoLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetSectioningInfoQuery, GetSectioningInfoQueryVariables>) {
-          return Apollo.useLazyQuery<GetSectioningInfoQuery, GetSectioningInfoQueryVariables>(GetSectioningInfoDocument, baseOptions);
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetSectioningInfoQuery, GetSectioningInfoQueryVariables>(GetSectioningInfoDocument, options);
         }
 export type GetSectioningInfoQueryHookResult = ReturnType<typeof useGetSectioningInfoQuery>;
 export type GetSectioningInfoLazyQueryHookResult = ReturnType<typeof useGetSectioningInfoLazyQuery>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "noFallthroughCasesInSwitch": true
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,6 +1591,16 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
+"@endemolshinegroup/cosmiconfig-typescript-loader@3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz#eea4635828dde372838b0909693ebd9aafeec22d"
+  integrity sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==
+  dependencies:
+    lodash.get "^4"
+    make-error "^1"
+    ts-node "^9"
+    tslib "^2"
+
 "@eslint/eslintrc@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.1.tgz#f72069c330461a06684d119384435e12a5d76e3c"
@@ -1615,13 +1625,13 @@
     postcss "7.0.32"
     purgecss "^3.0.0"
 
-"@graphql-codegen/cli@1.18.0":
-  version "1.18.0"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-1.18.0.tgz#8bfeba3748bbd314551dae609cc92002985e5385"
-  integrity sha512-dtQYLHb+hJ9CirJ0oNJgMpYHVjHXmr1JZUkqz1FF0ZweBt5syG9EHS5Upk+xoDUNsw63i8PDRgoZLZRvDFyyZw==
+"@graphql-codegen/cli@^1.21.3":
+  version "1.21.3"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/cli/-/cli-1.21.3.tgz#3506c5d019c6995be1927bd4d9c67a739fafe5e6"
+  integrity sha512-jwg0mKhseg0QI4/T4IQcttTBCZgnahiTWqnYWIK+E8nrbXCE9o2hxvaYin/Kq9+5oFtxDePED56cjVs/ESRw6g==
   dependencies:
-    "@graphql-codegen/core" "1.17.8"
-    "@graphql-codegen/plugin-helpers" "^1.17.9"
+    "@graphql-codegen/core" "1.17.9"
+    "@graphql-codegen/plugin-helpers" "^1.18.4"
     "@graphql-tools/apollo-engine-loader" "^6"
     "@graphql-tools/code-file-loader" "^6"
     "@graphql-tools/git-loader" "^6"
@@ -1631,19 +1641,18 @@
     "@graphql-tools/load" "^6"
     "@graphql-tools/prisma-loader" "^6"
     "@graphql-tools/url-loader" "^6"
-    "@graphql-tools/utils" "^6"
+    "@graphql-tools/utils" "^7.0.0"
     ansi-escapes "^4.3.1"
-    camel-case "^4.1.1"
     chalk "^4.1.0"
+    change-case-all "1.0.12"
     chokidar "^3.4.3"
     common-tags "^1.8.0"
-    constant-case "^3.0.3"
     cosmiconfig "^7.0.0"
     debounce "^1.2.0"
-    dependency-graph "^0.9.0"
+    dependency-graph "^0.11.0"
     detect-indent "^6.0.0"
     glob "^7.1.6"
-    graphql-config "^3.0.2"
+    graphql-config "^3.2.0"
     indent-string "^4.0.0"
     inquirer "^7.3.3"
     is-glob "^4.0.1"
@@ -1652,93 +1661,84 @@
     listr "^0.14.3"
     listr-update-renderer "^0.5.0"
     log-symbols "^4.0.0"
-    lower-case "^2.0.1"
     minimatch "^3.0.4"
     mkdirp "^1.0.4"
-    pascal-case "^3.1.1"
-    request "^2.88.2"
     string-env-interpolation "^1.0.1"
     ts-log "^2.2.3"
-    tslib "~2.0.1"
-    upper-case "^2.0.1"
+    tslib "~2.1.0"
     valid-url "^1.0.9"
     wrap-ansi "^7.0.0"
-    yargs "^16.0.3"
+    yaml "^1.10.0"
+    yargs "^16.1.1"
 
-"@graphql-codegen/core@1.17.8":
-  version "1.17.8"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-1.17.8.tgz#d70281bcf9f4b7b560ab5b16f7fc7a2853c49a8a"
-  integrity sha512-HUntoeLhLZf6wroD1HYLsniz51N3zW7cjgwojGKgbUsI6Oa8pGsh+kKaN9xtvlb/hIpsRJ00q9LbPVIM/kXQtQ==
-  dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.17.8"
-    "@graphql-tools/merge" "^6.0.18"
-    "@graphql-tools/utils" "^6.0.18"
-    tslib "~2.0.0"
-
-"@graphql-codegen/plugin-helpers@^1.17.8", "@graphql-codegen/plugin-helpers@^1.17.9":
+"@graphql-codegen/core@1.17.9":
   version "1.17.9"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.17.9.tgz#429f7f75b9f09f5229e42546027613f62ef0d4b1"
-  integrity sha512-kyj+qsnLGd1JLqXuLpvI6Q/VW7frhoHHNxYJWerpwsSV9m4cttmFj8d9JTfYPZbg6cLIRR7+10lVugzMKozjzA==
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/core/-/core-1.17.9.tgz#c03e71018ff04d26f5139a2d90a32b31d3bb2b43"
+  integrity sha512-7nwy+bMWqb0iYJ2DKxA9UiE16meeJ2Ch2XWS/N/ZnA0snTR+GZ20USI8z6YqP1Fuist7LvGO1MbitO2qBT8raA==
   dependencies:
+    "@graphql-codegen/plugin-helpers" "^1.18.2"
+    "@graphql-tools/merge" "^6"
     "@graphql-tools/utils" "^6"
-    camel-case "4.1.1"
+    tslib "~2.0.1"
+
+"@graphql-codegen/plugin-helpers@^1.18.2", "@graphql-codegen/plugin-helpers@^1.18.3", "@graphql-codegen/plugin-helpers@^1.18.4":
+  version "1.18.4"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.18.4.tgz#0adc4c0f88386a50b7a69d358080b6ee54fc3b16"
+  integrity sha512-dpfhUmn9GOS8ByoOPIN3V4Nn9HX7sl9NR7Hf26TgN6Clg7cQvkT6XjHdS2e56Q3kWrxZT1zJ1sEa67D3tj9ZtQ==
+  dependencies:
+    "@graphql-tools/utils" "^7.0.0"
     common-tags "1.8.0"
-    constant-case "3.0.3"
     import-from "3.0.0"
     lodash "~4.17.20"
-    lower-case "2.0.1"
-    param-case "3.0.3"
-    pascal-case "3.1.1"
-    tslib "~2.0.1"
-    upper-case "2.0.1"
+    tslib "~2.1.0"
 
-"@graphql-codegen/typescript-operations@1.17.8":
-  version "1.17.8"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-1.17.8.tgz#17c811c7a719df56fec0878f00b2b7449fb45165"
-  integrity sha512-nU1ZldRB4vGcg4FQhOp3GOOyjfIwO+cI110zZhxQw8SV7pbNDJnCckbvkdEOkW+1/jVJcUul8jQVvuym5olipw==
+"@graphql-codegen/typescript-operations@^1.17.15":
+  version "1.17.15"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-operations/-/typescript-operations-1.17.15.tgz#c992e29ead1cf5c3f65dbbe1f522b09be30c36d6"
+  integrity sha512-HStWj3mUe+0ir2J0jqgjegrvcO1DIe2gzsoBBo9RHIYwyaxedUivxXvWY9XBfKpHv6sLa/ST1iYGeedrJELPtw==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.17.8"
-    "@graphql-codegen/typescript" "^1.17.8"
-    "@graphql-codegen/visitor-plugin-common" "^1.17.13"
+    "@graphql-codegen/plugin-helpers" "^1.18.3"
+    "@graphql-codegen/typescript" "^1.21.1"
+    "@graphql-codegen/visitor-plugin-common" "^1.19.0"
     auto-bind "~4.0.0"
-    tslib "~2.0.0"
+    tslib "~2.1.0"
 
-"@graphql-codegen/typescript-react-apollo@2.0.7":
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-react-apollo/-/typescript-react-apollo-2.0.7.tgz#836642429259b73e7da40aa5d74c14fdf91337d6"
-  integrity sha512-vJunXm8sDXBeTPK5ULCpu9jMEJEnbI3kk7xXW1aNeoP+O56J2cJVj2vcy/1UwPQqhDPVoEvQv7sszm0bUE/Ljw==
+"@graphql-codegen/typescript-react-apollo@^2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript-react-apollo/-/typescript-react-apollo-2.2.3.tgz#d5f54e81235d29bb57daeeda4dd58500c4f9d1e4"
+  integrity sha512-6OjDJQfVwMDEqQkgoQ3Uixq3KRb0H+lSwcWWFmdWErYhe5k2F8niBUJ32FEwu0KIqqx3PhzdwmLcXpBTC5gtyg==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.17.9"
-    "@graphql-codegen/visitor-plugin-common" "^1.17.15"
+    "@graphql-codegen/plugin-helpers" "^1.18.4"
+    "@graphql-codegen/visitor-plugin-common" "^1.19.1"
     auto-bind "~4.0.0"
-    camel-case "^4.1.1"
-    pascal-case "^3.1.1"
-    tslib "~2.0.1"
+    change-case-all "1.0.12"
+    tslib "~2.1.0"
 
-"@graphql-codegen/typescript@1.17.11", "@graphql-codegen/typescript@^1.17.8":
-  version "1.17.11"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-1.17.11.tgz#9bcc00580b36e8c98e7cc565dbccaf1b8b8ce85d"
-  integrity sha512-cZsuOWpPWWHX7IIv2xMbrI/AZOiv+wEzyGpoGFV8zU6vjs54C50gb7Chhj9XPjMbOhUQ+z3Pn01geTRvi1gDeA==
+"@graphql-codegen/typescript@^1.21.1":
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/typescript/-/typescript-1.21.1.tgz#9bce3254b8ef30a6bf64e57ba3991f9be7a19b53"
+  integrity sha512-JF6Vsu5HSv3dAoS2ca3PFLUN0qVxotex/+BgWw/6SKhtd83MUPnzJ/RU3lACg4vuNTCWeQSeGvg8x5qrw9Go9w==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.17.9"
-    "@graphql-codegen/visitor-plugin-common" "^1.17.16"
+    "@graphql-codegen/plugin-helpers" "^1.18.3"
+    "@graphql-codegen/visitor-plugin-common" "^1.19.0"
     auto-bind "~4.0.0"
-    tslib "~2.0.1"
+    tslib "~2.1.0"
 
-"@graphql-codegen/visitor-plugin-common@^1.17.13", "@graphql-codegen/visitor-plugin-common@^1.17.15", "@graphql-codegen/visitor-plugin-common@^1.17.16":
-  version "1.17.16"
-  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.17.16.tgz#37316cbe2bb9ec4ff65d1f3287c72641d4b3fe6c"
-  integrity sha512-q/v13WA4gqD79VR+rrUPrTdLn43qaEuSfij9k52ti4GNKnXglGHP8ljXTrHKN6MypUxOJ2u7tcFRgriH1nxy6w==
+"@graphql-codegen/visitor-plugin-common@^1.19.0", "@graphql-codegen/visitor-plugin-common@^1.19.1":
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-1.19.1.tgz#2584588351a343a2ad8cd76dde62eb2ec25abe18"
+  integrity sha512-MJZXe5vXxV6PLOgHhQoz93gnjzJtbnVQXQKqVEcbyB9W8ImoKuTHsEf/eJ6yCL79f7X/2dnOOM84d5Osh1eaKg==
   dependencies:
-    "@graphql-codegen/plugin-helpers" "^1.17.9"
+    "@graphql-codegen/plugin-helpers" "^1.18.4"
+    "@graphql-tools/optimize" "^1.0.1"
     "@graphql-tools/relay-operation-optimizer" "^6"
-    array.prototype.flatmap "^1.2.3"
+    array.prototype.flatmap "^1.2.4"
     auto-bind "~4.0.0"
-    dependency-graph "^0.9.0"
+    change-case-all "1.0.12"
+    dependency-graph "^0.11.0"
     graphql-tag "^2.11.0"
     parse-filepath "^1.0.2"
-    pascal-case "^3.1.1"
-    tslib "~2.0.1"
+    tslib "~2.1.0"
 
 "@graphql-tools/apollo-engine-loader@^6":
   version "6.2.4"
@@ -1846,13 +1846,29 @@
     unixify "1.0.0"
     valid-url "1.0.9"
 
-"@graphql-tools/merge@^6.0.0", "@graphql-tools/merge@^6.0.18", "@graphql-tools/merge@^6.2.4":
+"@graphql-tools/merge@^6":
+  version "6.2.10"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-6.2.10.tgz#cadb37b1bed786cba1b3c6f728c5476a164e153d"
+  integrity sha512-dM3n37PcslvhOAkCz7Cwk0BfoiSVKXGmCX+VMZkATbXk/0vlxUfNEpVfA5yF4IkP27F04SzFQSaNrbD0W2Rszw==
+  dependencies:
+    "@graphql-tools/schema" "^7.0.0"
+    "@graphql-tools/utils" "^7.5.0"
+    tslib "~2.1.0"
+
+"@graphql-tools/merge@^6.0.0", "@graphql-tools/merge@^6.2.4":
   version "6.2.4"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-6.2.4.tgz#5b3b68083d55a38a7f3caac6e0adc46f428c2a3b"
   integrity sha512-hQbiSzCJgzUYG1Aspj5EAUY9DsbTI2OK30GLBOjUI16DWkoLVXLXy4ljQYJxq6wDc4fqixMOmvxwf8FoJ9okmw==
   dependencies:
     "@graphql-tools/schema" "^6.2.4"
     "@graphql-tools/utils" "^6.2.4"
+    tslib "~2.0.1"
+
+"@graphql-tools/optimize@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/optimize/-/optimize-1.0.1.tgz#9933fffc5a3c63f95102b1cb6076fb16ac7bb22d"
+  integrity sha512-cRlUNsbErYoBtzzS6zXahXeTBZGPVlPHXCpnEZ0XiK/KY/sQL96cyzak0fM/Gk6qEI9/l32MYEICjasiBQrl5w==
+  dependencies:
     tslib "~2.0.1"
 
 "@graphql-tools/prisma-loader@^6":
@@ -1902,6 +1918,14 @@
     "@graphql-tools/utils" "^6.2.4"
     tslib "~2.0.1"
 
+"@graphql-tools/schema@^7.0.0":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-7.1.3.tgz#d816400da51fbac1f0086e35540ab63b5e30e858"
+  integrity sha512-ZY76hmcJlF1iyg3Im0sQ3ASRkiShjgv102vLTVcH22lEGJeCaCyyS/GF1eUHom418S60bS8Th6+autRUxfBiBg==
+  dependencies:
+    "@graphql-tools/utils" "^7.1.2"
+    tslib "~2.1.0"
+
 "@graphql-tools/url-loader@^6", "@graphql-tools/url-loader@^6.0.0", "@graphql-tools/url-loader@^6.2.4":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-6.3.0.tgz#75b82bdf0983d3e389c75948a7abff20fa45a630"
@@ -1917,7 +1941,7 @@
     valid-url "1.0.9"
     websocket "1.0.32"
 
-"@graphql-tools/utils@^6", "@graphql-tools/utils@^6.0.0", "@graphql-tools/utils@^6.0.18", "@graphql-tools/utils@^6.2.4":
+"@graphql-tools/utils@^6", "@graphql-tools/utils@^6.0.0", "@graphql-tools/utils@^6.2.4":
   version "6.2.4"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.2.4.tgz#38a2314d2e5e229ad4f78cca44e1199e18d55856"
   integrity sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==
@@ -1925,6 +1949,15 @@
     "@ardatan/aggregate-error" "0.0.6"
     camel-case "4.1.1"
     tslib "~2.0.1"
+
+"@graphql-tools/utils@^7.0.0", "@graphql-tools/utils@^7.1.2", "@graphql-tools/utils@^7.5.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.6.0.tgz#ac570a2b5a9bcd5d6446995f58ba22609e01ca7d"
+  integrity sha512-YCZDDdhfb4Yhie0IH031eGdvQG8C73apDuNg6lqBNbauNw45OG/b8wi3+vuMiDnJTJN32GQUb1Gt9gxDKoRDKw==
+  dependencies:
+    "@ardatan/aggregate-error" "0.0.6"
+    camel-case "4.1.2"
+    tslib "~2.1.0"
 
 "@graphql-tools/wrap@^6.2.4":
   version "6.2.4"
@@ -2002,6 +2035,11 @@
   integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
+
+"@iarna/toml@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
+  integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -3492,6 +3530,11 @@ arch@^2.1.2:
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.2.tgz#0c52bbe7344bb4fa260c443d2cbad9c00ff2f0bf"
   integrity sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -3584,6 +3627,16 @@ array.prototype.flatmap@^1.2.3:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
+    function-bind "^1.1.1"
+
+array.prototype.flatmap@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz#94cfd47cc1556ec0747d97f7c7738c58122004c9"
+  integrity sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
     function-bind "^1.1.1"
 
 array.prototype.map@^1.0.1:
@@ -4387,6 +4440,14 @@ camel-case@4.1.1, camel-case@^4.1.1:
     pascal-case "^3.1.1"
     tslib "^1.10.0"
 
+camel-case@4.1.2, camel-case@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-4.1.2.tgz#9728072a954f805228225a6deea6b38461e1bd5a"
+  integrity sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==
+  dependencies:
+    pascal-case "^3.1.2"
+    tslib "^2.0.3"
+
 camelcase-css@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
@@ -4426,6 +4487,15 @@ caniuse-lite@^1.0.30001157:
   version "1.0.30001159"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz#bebde28f893fa9594dadcaa7d6b8e2aa0299df20"
   integrity sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==
+
+capital-case@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/capital-case/-/capital-case-1.0.4.tgz#9d130292353c9249f6b00fa5852bee38a717e669"
+  integrity sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -4479,6 +4549,40 @@ chalk@^4.0.0, chalk@^4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+change-case-all@1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/change-case-all/-/change-case-all-1.0.12.tgz#ae3e0faf5e610e8e25c5d5eaa4a6d5c2f1d68797"
+  integrity sha512-zdQus7R0lkprF99lrWUC5bFj6Nog4Xt4YCEjQ/vM4vbc6b5JHFBQMxRPAjfx+HJH8WxMzH0E+lQ8yQJLgmPCBg==
+  dependencies:
+    change-case "^4.1.1"
+    is-lower-case "^2.0.1"
+    is-upper-case "^2.0.1"
+    lower-case "^2.0.1"
+    lower-case-first "^2.0.1"
+    sponge-case "^1.0.0"
+    swap-case "^2.0.1"
+    title-case "^3.0.2"
+    upper-case "^2.0.1"
+    upper-case-first "^2.0.1"
+
+change-case@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-4.1.2.tgz#fedfc5f136045e2398c0410ee441f95704641e12"
+  integrity sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==
+  dependencies:
+    camel-case "^4.1.2"
+    capital-case "^1.0.4"
+    constant-case "^3.0.4"
+    dot-case "^3.0.4"
+    header-case "^2.0.4"
+    no-case "^3.0.4"
+    param-case "^3.0.4"
+    pascal-case "^3.1.2"
+    path-case "^3.0.4"
+    sentence-case "^3.0.4"
+    snake-case "^3.0.4"
+    tslib "^2.0.3"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -4916,14 +5020,14 @@ console-browserify@^1.1.0:
   resolved "https://registry.yarnpkg.com/console-browserify/-/console-browserify-1.2.0.tgz#67063cef57ceb6cf4993a2ab3a55840ae8c49336"
   integrity sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==
 
-constant-case@3.0.3, constant-case@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.3.tgz#ac910a99caf3926ac5112f352e3af599d8c5fc0a"
-  integrity sha512-FXtsSnnrFYpzDmvwDGQW+l8XK3GV1coLyBN0eBz16ZUzGaZcT2ANVCJmLeuw2GQgxKHQIe9e0w2dzkSfaRlUmA==
+constant-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-3.0.4.tgz#3b84a9aeaf4cf31ec45e6bf5de91bdfb0589faf1"
+  integrity sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==
   dependencies:
-    no-case "^3.0.3"
-    tslib "^1.10.0"
-    upper-case "^2.0.1"
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case "^2.0.2"
 
 constants-browserify@^1.0.0:
   version "1.0.0"
@@ -5027,6 +5131,13 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cosmiconfig-toml-loader@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig-toml-loader/-/cosmiconfig-toml-loader-1.0.0.tgz#0681383651cceff918177debe9084c0d3769509b"
+  integrity sha512-H/2gurFWVi7xXvCyvsWRLCMekl4tITJcX0QEsDMpzxtuxDyM59xLatYNg4s/k9AA/HdtCYfj2su8mgA0GSDLDA==
+  dependencies:
+    "@iarna/toml" "^2.2.5"
+
 cosmiconfig@6.0.0, cosmiconfig@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
@@ -5089,6 +5200,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-fetch@3.0.6, cross-fetch@^3.0.6:
   version "3.0.6"
@@ -5650,6 +5766,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+dependency-graph@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.11.0.tgz#ac0ce7ed68a54da22165a85e97a01d53f5eb2e27"
+  integrity sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==
+
 dependency-graph@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.9.0.tgz#11aed7e203bc8b00f48356d92db27b265c445318"
@@ -5715,7 +5836,7 @@ diff-sequences@^26.6.2:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
 
-diff@4.0.2:
+diff@4.0.2, diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
@@ -5863,6 +5984,14 @@ dot-case@^3.0.3:
   dependencies:
     no-case "^3.0.3"
     tslib "^1.10.0"
+
+dot-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
+  integrity sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 dot-prop@^5.2.0:
   version "5.2.0"
@@ -7379,11 +7508,12 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-config@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-3.0.3.tgz#58907c65ed7d6e04132321450b60e57863ea9a5f"
-  integrity sha512-MBY0wEjvcgJtZUyoqpPvOE1e5qPI0hJaa1gKTqjonSFiCsNHX2lykNjpOPcodmAgH1V06ELxhGnm9kcVzqvi/g==
+graphql-config@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/graphql-config/-/graphql-config-3.2.0.tgz#3ec3a7e319792086b80e54db4b37372ad4a79a32"
+  integrity sha512-ygEKDeQNZKpm4137560n2oY3bGM0D5zyRsQVaJntKkufWdgPg6sb9/4J1zJW2y/yC1ortAbhNho09qmeJeLa9g==
   dependencies:
+    "@endemolshinegroup/cosmiconfig-typescript-loader" "3.0.2"
     "@graphql-tools/graphql-file-loader" "^6.0.0"
     "@graphql-tools/json-file-loader" "^6.0.0"
     "@graphql-tools/load" "^6.0.0"
@@ -7391,6 +7521,7 @@ graphql-config@^3.0.2:
     "@graphql-tools/url-loader" "^6.0.0"
     "@graphql-tools/utils" "^6.0.0"
     cosmiconfig "6.0.0"
+    cosmiconfig-toml-loader "1.0.0"
     minimatch "3.0.4"
     string-env-interpolation "1.0.1"
     tslib "^2.0.0"
@@ -7535,6 +7666,14 @@ he@1.2.0, he@^1.1.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+header-case@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/header-case/-/header-case-2.0.4.tgz#5a42e63b55177349cf405beb8d775acabb92c063"
+  integrity sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==
+  dependencies:
+    capital-case "^1.0.4"
+    tslib "^2.0.3"
 
 headers-utils@^1.2.0:
   version "1.2.0"
@@ -8227,6 +8366,13 @@ is-installed-globally@^0.3.2:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
 
+is-lower-case@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-lower-case/-/is-lower-case-2.0.2.tgz#1c0884d3012c841556243483aa5d522f47396d2a"
+  integrity sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==
+  dependencies:
+    tslib "^2.0.3"
+
 is-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-map/-/is-map-2.0.1.tgz#520dafc4307bb8ebc33b813de5ce7c9400d644a1"
@@ -8403,6 +8549,13 @@ is-unc-path@^1.0.0:
   integrity sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==
   dependencies:
     unc-path-regex "^0.1.2"
+
+is-upper-case@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-upper-case/-/is-upper-case-2.0.2.tgz#f1105ced1fe4de906a5f39553e7d3803fd804649"
+  integrity sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==
+  dependencies:
+    tslib "^2.0.3"
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -9468,7 +9621,7 @@ lodash.forown@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.forown/-/lodash.forown-4.4.0.tgz#85115cf04f73ef966eced52511d3893cc46683af"
   integrity sha1-hRFc8E9z75ZuztUlEdOJPMRmg68=
 
-lodash.get@^4.4.2:
+lodash.get@^4, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -9603,12 +9756,26 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lower-case@2.0.1, lower-case@^2.0.1:
+lower-case-first@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-2.0.2.tgz#64c2324a2250bf7c37c5901e76a5b5309301160b"
+  integrity sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==
+  dependencies:
+    tslib "^2.0.3"
+
+lower-case@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.1.tgz#39eeb36e396115cc05e29422eaea9e692c9408c7"
   integrity sha512-LiWgfDLLb1dwbFQZsSglpRj+1ctGnayXz3Uv0/WO8n558JycT5fg6zkNcnW0G68Nn0aEldTFeEfmjCfmqry/rQ==
   dependencies:
     tslib "^1.10.0"
+
+lower-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
+  integrity sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==
+  dependencies:
+    tslib "^2.0.3"
 
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
@@ -9667,6 +9834,11 @@ make-dir@^3.0.2:
   integrity sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==
   dependencies:
     semver "^6.0.0"
+
+make-error@^1, make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -10140,6 +10312,14 @@ no-case@^3.0.3:
   dependencies:
     lower-case "^2.0.1"
     tslib "^1.10.0"
+
+no-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-3.0.4.tgz#d361fd5c9800f558551a8369fc0dcd4662b6124d"
+  integrity sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==
+  dependencies:
+    lower-case "^2.0.2"
+    tslib "^2.0.3"
 
 node-emoji@^1.8.1:
   version "1.10.0"
@@ -10718,13 +10898,21 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
-param-case@3.0.3, param-case@^3.0.3:
+param-case@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.3.tgz#4be41f8399eff621c56eebb829a5e451d9801238"
   integrity sha512-VWBVyimc1+QrzappRs7waeN2YmoZFCGXWASRYX1/rGHtXqEcrGEIDm+jqIwFa2fRXNgQEwrxaYuIrX0WcAguTA==
   dependencies:
     dot-case "^3.0.3"
     tslib "^1.10.0"
+
+param-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
+  integrity sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -10789,13 +10977,21 @@ parseurl@~1.3.2, parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
-pascal-case@3.1.1, pascal-case@^3.1.1:
+pascal-case@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.1.tgz#5ac1975133ed619281e88920973d2cd1f279de5f"
   integrity sha512-XIeHKqIrsquVTQL2crjq3NfJUxmdLasn3TYOU0VBM+UX2a6ztAWBlJQBePLGY7VHW8+2dRadeIPK5+KImwTxQA==
   dependencies:
     no-case "^3.0.3"
     tslib "^1.10.0"
+
+pascal-case@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-3.1.2.tgz#b48e0ef2b98e205e7c1dae747d0b1508237660eb"
+  integrity sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -10806,6 +11002,14 @@ path-browserify@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.1.tgz#e6c4ddd7ed3aa27c68a20cc4e50e1a4ee83bbc4a"
   integrity sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==
+
+path-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/path-case/-/path-case-3.0.4.tgz#9168645334eb942658375c56f80b4c0cb5f82c6f"
+  integrity sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
 
 path-dirname@^1.0.0:
   version "1.0.2"
@@ -13147,6 +13351,15 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
+sentence-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-3.0.4.tgz#3645a7b8c117c787fde8702056225bb62a45131f"
+  integrity sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==
+  dependencies:
+    no-case "^3.0.4"
+    tslib "^2.0.3"
+    upper-case-first "^2.0.2"
+
 serialize-javascript@4.0.0, serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
@@ -13317,6 +13530,14 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+snake-case@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-3.0.4.tgz#4f2bbd568e9935abdfd593f34c691dadb49c452c"
+  integrity sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==
+  dependencies:
+    dot-case "^3.0.4"
+    tslib "^2.0.3"
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -13391,18 +13612,18 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.6, source-map-support@~0.5.12:
-  version "0.5.16"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
-  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+source-map-support@^0.5.17, source-map-support@~0.5.19:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@~0.5.19:
-  version "0.5.19"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
-  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+source-map-support@^0.5.6, source-map-support@~0.5.12:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
+  integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -13499,6 +13720,13 @@ split@0.3:
   integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
   dependencies:
     through "2"
+
+sponge-case@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/sponge-case/-/sponge-case-1.0.1.tgz#260833b86453883d974f84854cdb63aecc5aef4c"
+  integrity sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==
+  dependencies:
+    tslib "^2.0.3"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -13943,6 +14171,13 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+swap-case@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/swap-case/-/swap-case-2.0.2.tgz#671aedb3c9c137e2985ef51c51f9e98445bf70d9"
+  integrity sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==
+  dependencies:
+    tslib "^2.0.3"
+
 symbol-observable@^1.0.4, symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
@@ -14168,6 +14403,13 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
+title-case@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/title-case/-/title-case-3.0.3.tgz#bc689b46f02e411f1d1e1d081f7c3deca0489982"
+  integrity sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==
+  dependencies:
+    tslib "^2.0.3"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -14285,6 +14527,18 @@ ts-log@^2.2.3:
   resolved "https://registry.yarnpkg.com/ts-log/-/ts-log-2.2.3.tgz#4da5640fe25a9fb52642cd32391c886721318efb"
   integrity sha512-XvB+OdKSJ708Dmf9ore4Uf/q62AYDTzFcAdxc8KNML1mmAWywRFVt/dn1KYJH8Agt5UJNujfM3znU5PxgAzA2w==
 
+ts-node@^9:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
+  dependencies:
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.17"
+    yn "3.1.1"
+
 ts-pnp@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -14315,7 +14569,12 @@ tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^2.0.0, tslib@~2.0.0, tslib@~2.0.1:
+tslib@^2, tslib@^2.0.3, tslib@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.0.0, tslib@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
@@ -14537,12 +14796,26 @@ upath@^1.1.1, upath@^1.1.2, upath@^1.2.0:
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
 
-upper-case@2.0.1, upper-case@^2.0.1:
+upper-case-first@^2.0.1, upper-case-first@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-2.0.2.tgz#992c3273f882abd19d1e02894cc147117f844324"
+  integrity sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==
+  dependencies:
+    tslib "^2.0.3"
+
+upper-case@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.1.tgz#6214d05e235dc817822464ccbae85822b3d8665f"
   integrity sha512-laAsbea9SY5osxrv7S99vH9xAaJKrw5Qpdh4ENRLcaxipjKsiaBwiAsxfa8X5mObKNTQPsupSq0J/VIxsSJe3A==
   dependencies:
     tslib "^1.10.0"
+
+upper-case@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-2.0.2.tgz#d89810823faab1df1549b7d97a76f8662bae6f7a"
+  integrity sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==
+  dependencies:
+    tslib "^2.0.3"
 
 uri-js@^4.2.2:
   version "4.2.2"
@@ -15441,6 +15714,19 @@ yargs@^16.0.3:
     y18n "^5.0.1"
     yargs-parser "^20.0.0"
 
+yargs@^16.1.1:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
 yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
@@ -15448,6 +15734,11 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yup@^0.29.3:
   version "0.29.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4473,20 +4473,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001035:
-  version "1.0.30001035"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz#2bb53b8aa4716b2ed08e088d4dc816a5fe089a1e"
-  integrity sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ==
-
-caniuse-lite@^1.0.30001125:
-  version "1.0.30001162"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001162.tgz#9f83aad1f42539ce9aab58bb177598f2f8e22ec6"
-  integrity sha512-E9FktFxaNnp4ky3ucIGzEXLM+Knzlpuq1oN1sFAU0KeayygabGTmOsndpo8QrL4D9pcThlf4D2pUKaDxPCUmVw==
-
-caniuse-lite@^1.0.30001157:
-  version "1.0.30001159"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz#bebde28f893fa9594dadcaa7d6b8e2aa0299df20"
-  integrity sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001020, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001157:
+  version "1.0.30001204"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz"
+  integrity sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Validate bio state on release page

Labware scan panels now support a check function for labware that is run before
the labware is added to the table.
The release page uses this to check labware's bio state.
Labware scan panel columns relating to samples now show info for all samples in the labware, not just the first.
For the release page (and probably others) it would probably be better if the table had a row per
labware-slot-sample instead of a row per labware.