### PR TITLE
Fixes RT#737516

### DIFF
--- a/src/components/labwareScanner/LabwareScanner.tsx
+++ b/src/components/labwareScanner/LabwareScanner.tsx
@@ -202,6 +202,7 @@ export default function LabwareScanner({
             disabled={!current.matches("idle")}
             onChange={handleOnScanInputChange}
             onScan={handleOnScan}
+            ref={inputRef}
           />
         </div>
       </div>

--- a/src/components/labwareScanner/LabwareScanner.tsx
+++ b/src/components/labwareScanner/LabwareScanner.tsx
@@ -96,7 +96,7 @@ export default function LabwareScanner({
   const inputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
     const subscription = service.subscribe((observer) => {
-      if (observer.matches("idle")) {
+      if (observer.matches("idle") && !observer.context.locationScan) {
         inputRef.current?.focus();
       }
     });


### PR DESCRIPTION
In Chrome, inputs don't regain focus when they go from enabled, to disabled, then back to
enabled (unlike Firefox). The code compensates for that by
explicitly focusing an input after a barcode scan. However, the reference to
the input wasn't being set up correctly. This tiny commit fixes that.