### PR TITLE
 R&D worknumber fix

### DIFF
--- a/cypress/integration/pages/workAllocationSpec.ts
+++ b/cypress/integration/pages/workAllocationSpec.ts
@@ -10,7 +10,9 @@ describe("Work Allocation", () => {
       "when I submit the form without selecting a work type, project, or cost code",
       () => {
         before(() => {
-          cy.findByRole("button", { name: /Submit/i }).click();
+          cy.findByRole("button", { name: /Submit/i })
+            .scrollIntoView()
+            .click();
         });
 
         it("says the work type is required", () => {

--- a/src/pages/WorkProgress.tsx
+++ b/src/pages/WorkProgress.tsx
@@ -180,7 +180,11 @@ const columns: Column<WorkProgressResultTableEntry>[] = [
     Cell: (props: Cell<HistoryTableEntry>) => {
       const workNumber = props.row.original.workNumber;
       return (
-        <StyledLink to={`/history/?kind=workNumber&value=${workNumber}`}>
+        <StyledLink
+          to={`/history/?kind=workNumber&value=${
+            workNumber ? encodeURIComponent(workNumber) : workNumber
+          }`}
+        >
           {workNumber}
         </StyledLink>
       );


### PR DESCRIPTION
if you click an R&D worknumber and it takes you to the history page but doesn't search/pull up the information on that worknumber and in the search bar it just has "R"