### PR TITLE
X803 perm control to an empty slot

### DIFF
--- a/cypress/integration/pages/visiumPermSpec.ts
+++ b/cypress/integration/pages/visiumPermSpec.ts
@@ -14,7 +14,24 @@ describe("Visium Perm", () => {
       before(() => cy.findByRole("button", { name: "Submit" }).click());
 
       it("submits the form", () => {
-        cy.findByText("Visium Permabilisation complete").should("be.visible");
+        cy.findByText("Visium Permeabilisation complete").should("be.visible");
+      });
+    });
+  });
+  describe("checking control barcode input", () => {
+    before(() => {
+      cy.get("#labwareScanInput").type("STAN-411{enter}");
+    });
+
+    it("enables the button", () => {
+      cy.findByRole("button", { name: "Submit" }).should("not.be.disabled");
+    });
+
+    context("when clicking Submit", () => {
+      before(() => cy.findByRole("button", { name: "Submit" }).click());
+
+      it("submits the form", () => {
+        cy.findByText("Visium Permeabilisation complete").should("be.visible");
       });
     });
   });

--- a/cypress/integration/pages/visiumPermSpec.ts
+++ b/cypress/integration/pages/visiumPermSpec.ts
@@ -71,7 +71,7 @@ describe("Visium Perm", () => {
           cy.findAllByRole("button").click();
         });
       });
-      it("removes the control tube assigned from all slots", () => {
+      it("removes the control tube assigned", () => {
         cy.findAllByText("STAN-3111").should("not.exist");
       });
     });

--- a/cypress/integration/pages/visiumPermSpec.ts
+++ b/cypress/integration/pages/visiumPermSpec.ts
@@ -3,7 +3,7 @@ describe("Visium Perm", () => {
 
   describe("filling in form", () => {
     before(() => {
-      cy.get("#labwareScanInput").type("STAN-411{enter}");
+      cy.get("#labwareScanInput").type("STAN-4111{enter}");
     });
 
     it("enables the button", () => {
@@ -18,18 +18,71 @@ describe("Visium Perm", () => {
       });
     });
   });
-  describe("checking control barcode input", () => {
+
+  describe("scanning labware with empty slots", () => {
     before(() => {
-      cy.get("#labwareScanInput").type("STAN-411{enter}");
+      cy.visit("/lab/visium_perm");
+      cy.get("#labwareScanInput").type("STAN-4011{enter}");
     });
 
-    it("enables the button", () => {
-      cy.findByRole("button", { name: "Submit" }).should("not.be.disabled");
+    it("displays control tube scanner", () => {
+      cy.findByText("Control Tube").should("be.visible");
     });
 
-    context("when clicking Submit", () => {
-      before(() => cy.findByRole("button", { name: "Submit" }).click());
+    context("when user scans control tube", () => {
+      before(() => {
+        cy.findByTestId("controltubeDiv").within(() => {
+          cy.get("#labwareScanInput").type("STAN-3111{enter}");
+        });
+      });
+      it("displays the table with control tube", () => {
+        cy.findByText("STAN-3111").should("be.visible");
+      });
+      it("displays Positive control checkbox for all slots", () => {
+        cy.findAllByRole("checkbox", { name: /Positive Control/i }).should(
+          "have.length",
+          4
+        );
+      });
+    });
 
+    context("when a control tube is selected for A1", () => {
+      before(() => {
+        cy.findAllByRole("checkbox").eq(0).click();
+      });
+      it("displays the control tube barcode for A1 slot", () => {
+        cy.findAllByTestId("permData.0.label").should("have.text", "STAN-3111");
+      });
+    });
+
+    context("when address A2 is assigned with control tube", () => {
+      before(() => {
+        cy.findAllByRole("checkbox").eq(1).click();
+      });
+      it("removes the control tube from A1 and displays in A2", () => {
+        cy.findAllByTestId("permData.0.label").should("have.text", "");
+        cy.findAllByTestId("permData.1.label").should("have.text", "STAN-3111");
+      });
+    });
+
+    context("when scanned control tube is removed", () => {
+      before(() => {
+        cy.findByTestId("controltubeDiv").within(() => {
+          cy.findAllByRole("button").click();
+        });
+      });
+      it("removes the control tube assigned from all slots", () => {
+        cy.findAllByText("STAN-3111").should("not.exist");
+      });
+    });
+    context("when submit button clicked with control tube data", () => {
+      before(() => {
+        cy.findByTestId("controltubeDiv").within(() => {
+          cy.get("#labwareScanInput").type("STAN-3111{enter}");
+        });
+        cy.findAllByRole("checkbox").eq(1).click();
+        cy.findByRole("button", { name: "Submit" }).click();
+      });
       it("submits the form", () => {
         cy.findByText("Visium Permeabilisation complete").should("be.visible");
       });

--- a/src/components/forms/PermPositiveControl.stories.tsx
+++ b/src/components/forms/PermPositiveControl.stories.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+import { Meta } from "@storybook/react";
+
+import PermPositiveControl from "./PermPositiveControl";
+import { Form, Formik } from "formik";
+import { RecordPermRequest } from "../../types/sdk";
+import BlueButton from "../buttons/BlueButton";
+
+export default {
+  title: "Forms/Formik/PermPositiveControl",
+  component: PermPositiveControl,
+} as Meta;
+
+export const Primary = () => {
+  return (
+    <Formik<RecordPermRequest>
+      onSubmit={async (values) => alert(JSON.stringify(values))}
+      initialValues={{
+        barcode: "STAN-123",
+        workNumber: "SGP-456",
+        permData: [
+          {
+            address: "A1",
+            controlBarcode: "STAN-123",
+          },
+        ],
+      }}
+    >
+      <Form>
+        <PermPositiveControl name={"permData[0]"} controlTube={undefined} />
+        <BlueButton type={"submit"}>Submit</BlueButton>
+      </Form>
+    </Formik>
+  );
+};

--- a/src/components/forms/PermPositiveControl.tsx
+++ b/src/components/forms/PermPositiveControl.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from "react";
+import { Field, useFormikContext } from "formik";
+import { Input } from "./Input";
+import Label from "./Label";
+import { ControlType, LabwareFieldsFragment, PermData } from "../../types/sdk";
+import { FormikErrorMessage, formikName } from "./index";
+
+type PermPositiveControlProps = {
+  /**
+   * The name of the Formik field. Will be used as the prefix for {@link PermData PermData's} properties
+   * e.g. a name of {@code "permData.0"} will produce properties such as {@code "permData.0.address"}
+   */
+  name: string;
+
+  /**
+   * The tube to be added to a slot as a control
+   */
+  controlTube: LabwareFieldsFragment | undefined;
+};
+
+/**
+ * {@link PermData} Formik input
+ */
+export default function PermPositiveControl<T>({
+  name,
+  controlTube,
+}: PermPositiveControlProps) {
+  const { setFieldValue, getFieldProps } = useFormikContext<T>();
+  const [isControl, setIsControl] = useState(false);
+  const permData = getFieldProps<PermData>(name).value;
+  /**
+   * When the control checkbox is checked, set/unset seconds and controlType
+   */
+  function onIsControlChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const isChecked = e.target.checked;
+
+    setFieldValue(name, {
+      address: permData.address,
+      seconds: isChecked ? undefined : 1,
+      controlType: isChecked ? ControlType.Positive : undefined,
+      controlBarcode: isChecked && controlTube ? controlTube.barcode : "",
+    });
+
+    setIsControl(isChecked);
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-row items-center gap-x-2">
+        <Label htmlFor={`${name}checkbox`} name={"Positive Control?"} />
+        <Input
+          type="checkbox"
+          id={`${name}checkbox`}
+          checked={isControl}
+          onChange={onIsControlChange}
+        />
+      </div>
+
+      {
+        <>
+          <Label name={"Control Tube"}>
+            <Field name={formikName(name, "controlBarcode")}>
+              {({ field }: any) => (
+                <Input
+                  disabled={true}
+                  value={field.value ?? ""} // Stops react complaining about "controlled/uncontrolled" inputs
+                  className="flex flex-col font-medium text-blue-500"
+                />
+              )}
+            </Field>
+          </Label>
+          <FormikErrorMessage name={name} />
+        </>
+      }
+    </div>
+  );
+}

--- a/src/components/forms/PermPositiveControl.tsx
+++ b/src/components/forms/PermPositiveControl.tsx
@@ -88,7 +88,11 @@ export default function PermPositiveControl<T>({
         <Label name={"Control Tube:"} />
         <Field name={formikName(name, "controlBarcode")}>
           {({ field }: any) => (
-            <Label name={""} className="font-bold text-blue-500">
+            <Label
+              data-testid={`${name}.label`}
+              name={""}
+              className="font-bold text-blue-500"
+            >
               {field.value ?? ""}
             </Label>
           )}

--- a/src/components/labware/SlotColumnInfo.tsx
+++ b/src/components/labware/SlotColumnInfo.tsx
@@ -19,11 +19,12 @@ const SlotColumnInfo = ({
   return (
     <div className={gridClasses}>
       {slotColumn.map((slot) => (
-        <div
-          key={slot.address}
-          className={`flex flex-col ${alignRight && "items-end"}`}
-        >
-          <div className={"flex font-medium"}>{slot.address}</div>
+        <div key={slot.address}>
+          <div
+            className={`flex flex-col ${alignRight && "items-end"} font-medium`}
+          >
+            {slot.address}
+          </div>
           <div className={"flex"}>{slotBuilder(slot)}</div>
         </div>
       ))}

--- a/src/mocks/handlers/labwareHandlers.ts
+++ b/src/mocks/handlers/labwareHandlers.ts
@@ -48,9 +48,6 @@ const labwareHandlers = [
       }
 
       const labware = createLabware(barcode);
-      labware.slots[0].samples = [];
-      labware.slots[1].samples = [];
-      labware.slots[5].samples = [];
       const payload: FindLabwareQuery = {
         labware: buildLabwareFragment(labware),
       };

--- a/src/mocks/handlers/labwareHandlers.ts
+++ b/src/mocks/handlers/labwareHandlers.ts
@@ -49,7 +49,8 @@ const labwareHandlers = [
 
       const labware = createLabware(barcode);
       labware.slots[0].samples = [];
-
+      labware.slots[1].samples = [];
+      labware.slots[5].samples = [];
       const payload: FindLabwareQuery = {
         labware: buildLabwareFragment(labware),
       };

--- a/src/mocks/handlers/labwareHandlers.ts
+++ b/src/mocks/handlers/labwareHandlers.ts
@@ -48,6 +48,7 @@ const labwareHandlers = [
       }
 
       const labware = createLabware(barcode);
+      labware.slots[0].samples = [];
 
       const payload: FindLabwareQuery = {
         labware: buildLabwareFragment(labware),

--- a/src/pages/VisiumPerm.tsx
+++ b/src/pages/VisiumPerm.tsx
@@ -25,7 +25,11 @@ import * as Yup from "yup";
 import { FormikErrorMessage } from "../components/forms";
 import Warning from "../components/notifications/Warning";
 import OperationCompleteModal from "../components/modal/OperationCompleteModal";
-import { isSlotEmpty, isSlotFilled } from "../lib/helpers/slotHelper";
+import {
+  emptySlots,
+  isSlotEmpty,
+  isSlotFilled,
+} from "../lib/helpers/slotHelper";
 import columns from "../components/dataTable/labwareColumns";
 import LabwareScanPanel from "../components/labwareScanPanel/LabwareScanPanel";
 import PermPositiveControl from "../components/forms/PermPositiveControl";
@@ -88,7 +92,7 @@ export default function VisiumPerm() {
   return (
     <AppShell>
       <AppShell.Header>
-        <AppShell.Title>Visium Permabilisation</AppShell.Title>
+        <AppShell.Title>Visium Permeabilisation</AppShell.Title>
       </AppShell.Header>
       <AppShell.Main>
         <div className="max-w-screen-xl mx-auto">
@@ -222,30 +226,35 @@ function VisiumPermForm() {
   };
 
   return (
-    <>
+    <div data-testid={"controltubeDiv"} className={"space-y-2"}>
       <FormikInput
         label={""}
         name={"barcode"}
         type={"hidden"}
         value={labwares[0].barcode}
       />
-      <div className="flex flex-row" />
-      <Heading level={2}>Control Tube</Heading>
-      <p>Please scan in the tube you wish to assign as a control tube.</p>
-      <div className="flex flex-row" />
-      <LabwareScanner
-        onAdd={(labware) => {
-          setControlTube(labware);
-        }}
-        onRemove={() => {
-          setControlTube(undefined);
-        }}
-        limit={1}
-      >
-        <LabwareScanPanel columns={[columns.barcode()]} />
-      </LabwareScanner>
-      <div className="flex flex-row" />
-      <div className="mt-10 flex flex-row items-center justify-around">
+      {labwares[0] && emptySlots(labwares[0].slots).length !== 0 && (
+        <>
+          <div className="flex flex-row" />
+          <Heading level={2}>Control Tube</Heading>
+          <p>Please scan in the tube you wish to assign as a control tube.</p>
+          <div className="flex flex-row" />
+          <LabwareScanner
+            onAdd={(labware) => {
+              setControlTube(labware);
+            }}
+            onRemove={() => {
+              setControlTube(undefined);
+            }}
+            limit={1}
+          >
+            <LabwareScanPanel columns={[columns.barcode()]} />
+          </LabwareScanner>
+          <div className="flex flex-row" />
+        </>
+      )}
+
+      <div className="flex flex-row items-center justify-around">
         <Labware
           labware={labwares[0]}
           slotBuilder={(slot: SlotFieldsFragment) => {
@@ -267,6 +276,6 @@ function VisiumPermForm() {
           }}
         />
       </div>
-    </>
+    </div>
   );
 }

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -1313,6 +1313,8 @@ export type PermData = {
   seconds?: Maybe<Scalars['Int']>;
   /** The control type, if this is a control. */
   controlType?: Maybe<ControlType>;
+  /** The barcode of the labware being put into this slot as a control, if there is one. */
+  controlBarcode?: Maybe<Scalars['String']>;
 };
 
 /** A planned action in a planned operation; describes a sample moving from one slot to another. */


### PR DESCRIPTION
Adding a positive control to an empty slot on the visium perm. feature -

- Scanning of control tube
- Assigning control tube to an empty slot as positive control
- Only one empty slot will be assigned with the control tube at a time
- Deletion of a control tube removes it from assigned empty slot