### PR TITLE
X846 auto section number

### DIFF
--- a/cypress/integration/pages/sectioningConfirmationSpec.ts
+++ b/cypress/integration/pages/sectioningConfirmationSpec.ts
@@ -137,6 +137,7 @@ describe("Sectioning Confirmation", () => {
             .then((col) => {
               highestSectionNumber = Number(col.text());
             });
+
           cy.findAllByTestId("labware-comments").each((elem) => {
             highestSectionNumber++;
             cy.wrap(elem)
@@ -149,6 +150,7 @@ describe("Sectioning Confirmation", () => {
         });
       }
     );
+
     context("when 'manual' mode is selected for section numbering", () => {
       before(() => {
         cy.get('[type = "radio"]').eq(1).click();

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -47,7 +47,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   (props, ref) => {
     const inputClassNames = classNames(
       {
-        "w-full disabled:bg-gray-200": props.type !== "checkbox",
+        "w-full disabled:bg-gray-200":
+          props.type !== "checkbox" || props.type !== "radio",
       },
       defaultInputClassNames
     );

--- a/src/components/forms/RadioGroup.tsx
+++ b/src/components/forms/RadioGroup.tsx
@@ -37,14 +37,9 @@ export default RadioGroup;
 interface RadioButtonParameters {
   name: string;
   value: string;
-  checked?: boolean;
 }
 
-export const RadioButton = ({
-  name,
-  value,
-  checked = false,
-}: RadioButtonParameters) => {
+export const RadioButton = ({ name, value }: RadioButtonParameters) => {
   const ctx = useContext(RadioGroupContext);
   return (
     <label className="inline-flex items-center">
@@ -53,7 +48,6 @@ export const RadioButton = ({
         className="form-radio text-sp"
         name={ctx.name}
         value={value}
-        checked={checked}
       />
       <span className="ml-2">{name}</span>
     </label>

--- a/src/components/forms/RadioGroup.tsx
+++ b/src/components/forms/RadioGroup.tsx
@@ -6,11 +6,17 @@ interface RadioGroupProps {
   label: string;
   name: string;
   children: React.ReactNode;
+  withFormik?: boolean;
 }
 
 const RadioGroupContext = React.createContext({ name: "" });
 
-const RadioGroup = ({ label, name, children }: RadioGroupProps) => {
+const RadioGroup = ({
+  label,
+  name,
+  children,
+  withFormik = true,
+}: RadioGroupProps) => {
   return (
     <>
       <div className="mt-2">
@@ -21,7 +27,7 @@ const RadioGroup = ({ label, name, children }: RadioGroupProps) => {
           </RadioGroupContext.Provider>
         </div>
       </div>
-      <FormikErrorMessage name={name} />
+      {withFormik && <FormikErrorMessage name={name} />}
     </>
   );
 };
@@ -31,9 +37,14 @@ export default RadioGroup;
 interface RadioButtonParameters {
   name: string;
   value: string;
+  checked?: boolean;
 }
 
-export const RadioButton = ({ name, value }: RadioButtonParameters) => {
+export const RadioButton = ({
+  name,
+  value,
+  checked = false,
+}: RadioButtonParameters) => {
   const ctx = useContext(RadioGroupContext);
   return (
     <label className="inline-flex items-center">
@@ -42,8 +53,34 @@ export const RadioButton = ({ name, value }: RadioButtonParameters) => {
         className="form-radio text-sp"
         name={ctx.name}
         value={value}
+        checked={checked}
       />
       <span className="ml-2">{name}</span>
     </label>
   );
 };
+
+interface RadioButtonProps
+  extends React.DetailedHTMLProps<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
+  > {
+  label: string;
+}
+export const RadioButtonInput = React.forwardRef<
+  HTMLInputElement,
+  RadioButtonProps
+>((props, ref) => {
+  const ctx = useContext(RadioGroupContext);
+  return (
+    <label className="inline-flex items-center">
+      <input
+        ref={ref}
+        {...props}
+        type={"radio"}
+        name={ctx.name ?? props.name}
+      />
+      <span className="ml-2">{props.label}</span>
+    </label>
+  );
+});

--- a/src/components/sectioningConfirm/ConfirmLabware.tsx
+++ b/src/components/sectioningConfirm/ConfirmLabware.tsx
@@ -22,14 +22,21 @@ import {
 } from "../../pages/sectioning";
 import { createConfirmLabwareMachine } from "./confirmLabware.machine";
 import { LayoutPlan } from "../../lib/machines/layout/layoutContext";
-import { CommentFieldsFragment, ConfirmSectionLabware } from "../../types/sdk";
+import {
+  CommentFieldsFragment,
+  ConfirmSectionLabware,
+  LabwareFieldsFragment,
+} from "../../types/sdk";
 import { selectConfirmOperationLabware } from "./index";
 import RemoveButton from "../buttons/RemoveButton";
 
 interface ConfirmLabwareProps {
   originalLayoutPlan: LayoutPlan;
   comments: Array<CommentFieldsFragment>;
-  onChange: (labware: ConfirmSectionLabware) => void;
+  onChange: (
+    labware: ConfirmSectionLabware,
+    sourceLabwares: LabwareFieldsFragment[]
+  ) => void;
   onRemoveClick: (labwareBarcode: string) => void;
   disableSectionNumbers?: boolean;
 }
@@ -66,9 +73,14 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
 
   useEffect(() => {
     if (confirmOperationLabware) {
-      onChange(confirmOperationLabware);
+      onChange(
+        confirmOperationLabware,
+        Array.from(layoutPlan.plannedActions.values()).flatMap((sources) =>
+          Array.from(sources.values()).map((source) => source.labware)
+        )
+      );
     }
-  }, [onChange, confirmOperationLabware]);
+  }, [onChange, confirmOperationLabware, layoutPlan.plannedActions]);
 
   /***Update section numbers whenever there is an update in section numbers in parent**/
   useEffect(() => {
@@ -83,7 +95,10 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
       className="relative p-3 shadow"
     >
       <RemoveButton onClick={() => onRemoveClick(labware.barcode!)} />
-      <div className="md:grid md:grid-cols-2">
+      <div
+        data-testid={`div-slide-${labware.barcode}`}
+        className="md:grid md:grid-cols-2"
+      >
         <div className="py-4 flex flex-col items-center justify-between space-y-8">
           <Labware
             labware={labware}

--- a/src/components/sectioningConfirm/ConfirmLabware.tsx
+++ b/src/components/sectioningConfirm/ConfirmLabware.tsx
@@ -31,6 +31,7 @@ interface ConfirmLabwareProps {
   comments: Array<CommentFieldsFragment>;
   onChange: (labware: ConfirmSectionLabware) => void;
   onRemoveClick: (labwareBarcode: string) => void;
+  disableSectionNumbers?: boolean;
 }
 
 const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
@@ -38,6 +39,7 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
   comments,
   onChange,
   onRemoveClick,
+  disableSectionNumbers = false,
 }) => {
   const [current, send, service] = useMachine(
     createConfirmLabwareMachine(
@@ -57,6 +59,10 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
     }
   }, [onChange, confirmOperationLabware]);
 
+  useEffect(() => {
+    send("UPDATE_ALL_SECTION_NUMBERS", originalLayoutPlan);
+  }, [originalLayoutPlan, send]);
+
   const { addressToCommentMap, labware, layoutPlan } = current.context;
 
   const { layoutMachine } = current.children;
@@ -68,7 +74,6 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
     },
     "grid grid-cols-1 gap-x-8 gap-y-2"
   );
-
   return (
     <motion.div
       variants={variants.fadeInWithLift}
@@ -108,7 +113,8 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
                   key={slot.address}
                   slot={slot}
                   value={addressToCommentMap.get(slot.address) ?? ""}
-                  disabled={current.matches("done")}
+                  disabledComment={current.matches("done")}
+                  disabledSectionNumber={disableSectionNumbers}
                   comments={comments}
                   layoutPlan={layoutPlan}
                   onCommentChange={(e) => {

--- a/src/components/sectioningConfirm/ConfirmLabware.tsx
+++ b/src/components/sectioningConfirm/ConfirmLabware.tsx
@@ -70,7 +70,7 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
     }
   }, [onChange, confirmOperationLabware]);
 
-  /**Update for section numbers changes in parent**/
+  /***Update section numbers whenever there is an update in section numbers in parent**/
   useEffect(() => {
     send("UPDATE_ALL_SECTION_NUMBERS", originalLayoutPlan);
   }, [originalLayoutPlan, send]);

--- a/src/components/sectioningConfirm/ConfirmLabware.tsx
+++ b/src/components/sectioningConfirm/ConfirmLabware.tsx
@@ -37,7 +37,7 @@ interface ConfirmLabwareProps {
     labware: ConfirmSectionLabware,
     sourceLabwares: LabwareFieldsFragment[]
   ) => void;
-  onRemoveClick: (labwareBarcode: string) => void;
+  onRemoveClick: (layoutPlan: LayoutPlan) => void;
   disableSectionNumbers?: boolean;
 }
 
@@ -94,7 +94,10 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
       animate={"visible"}
       className="relative p-3 shadow"
     >
-      <RemoveButton onClick={() => onRemoveClick(labware.barcode!)} />
+      <RemoveButton
+        data-testid={`remove-slide-${labware.barcode}`}
+        onClick={() => onRemoveClick(layoutPlan)}
+      />
       <div
         data-testid={`div-slide-${labware.barcode}`}
         className="md:grid md:grid-cols-2"

--- a/src/components/sectioningConfirm/ConfirmLabware.tsx
+++ b/src/components/sectioningConfirm/ConfirmLabware.tsx
@@ -30,7 +30,6 @@ interface ConfirmLabwareProps {
   originalLayoutPlan: LayoutPlan;
   comments: Array<CommentFieldsFragment>;
   onChange: (labware: ConfirmSectionLabware) => void;
-  onPlanLayoutChange: (layoutPlan: LayoutPlan) => void;
   onRemoveClick: (labwareBarcode: string) => void;
   disableSectionNumbers?: boolean;
 }
@@ -39,7 +38,6 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
   originalLayoutPlan,
   comments,
   onChange,
-  onPlanLayoutChange,
   onRemoveClick,
   disableSectionNumbers = false,
 }) => {
@@ -54,7 +52,6 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
     service,
     selectConfirmOperationLabware
   );
-  const sectionsInSlotChanged = React.useRef<boolean>(false);
 
   const { addressToCommentMap, labware, layoutPlan } = current.context;
   const { layoutMachine } = current.children;
@@ -77,14 +74,6 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
   useEffect(() => {
     send("UPDATE_ALL_SECTION_NUMBERS", originalLayoutPlan);
   }, [originalLayoutPlan, send]);
-
-  useEffect(() => {
-    /**Sections in a slot is changed, so notify parent**/
-    if (sectionsInSlotChanged.current) {
-      onPlanLayoutChange(layoutPlan);
-      sectionsInSlotChanged.current = false;
-    }
-  }, [layoutPlan, onPlanLayoutChange]);
 
   return (
     <motion.div
@@ -188,7 +177,6 @@ const ConfirmLabware: React.FC<ConfirmLabwareProps> = ({
         <ModalFooter>
           <BlueButton
             onClick={() => {
-              sectionsInSlotChanged.current = true;
               layoutMachine.send({ type: "DONE" });
             }}
             className="w-full text-base sm:ml-3 sm:w-auto sm:text-sm"

--- a/src/components/sectioningConfirm/ConfirmTubes.tsx
+++ b/src/components/sectioningConfirm/ConfirmTubes.tsx
@@ -25,8 +25,6 @@ interface ConfirmTubesProps {
   layoutPlans: Array<LayoutPlan>;
   comments: Array<CommentFieldsFragment>;
   onChange: (labware: ConfirmSectionLabware) => void;
-  onPlanLayoutChange: (layoutPlan: LayoutPlan) => void;
-  onPlanCancelled: (layoutPlan: LayoutPlan, cancelled: boolean) => void;
   disableSectionNumbers?: boolean;
 }
 
@@ -34,8 +32,6 @@ const ConfirmTubes: React.FC<ConfirmTubesProps> = ({
   layoutPlans,
   comments,
   onChange,
-  onPlanLayoutChange,
-  onPlanCancelled,
   disableSectionNumbers = false,
 }) => {
   return (
@@ -65,8 +61,6 @@ const ConfirmTubes: React.FC<ConfirmTubesProps> = ({
                 initialLayoutPlan={layoutPlan}
                 comments={comments}
                 onChange={onChange}
-                onPlanLayoutChange={onPlanLayoutChange}
-                onPlanCancelled={onPlanCancelled}
                 disableSectionNumbers={disableSectionNumbers}
               />
             ))}
@@ -83,8 +77,6 @@ interface TubeRowProps {
   initialLayoutPlan: LayoutPlan;
   comments: Array<CommentFieldsFragment>;
   onChange: (labware: ConfirmSectionLabware) => void;
-  onPlanLayoutChange: (layoutPlan: LayoutPlan) => void;
-  onPlanCancelled: (layoutPlan: LayoutPlan, cancelled: boolean) => void;
   disableSectionNumbers?: boolean;
 }
 
@@ -92,8 +84,6 @@ const TubeRow: React.FC<TubeRowProps> = ({
   initialLayoutPlan,
   comments,
   onChange,
-  onPlanLayoutChange,
-  onPlanCancelled,
   disableSectionNumbers = false,
 }) => {
   const [current, send, service] = useMachine(
@@ -123,14 +113,6 @@ const TubeRow: React.FC<TubeRowProps> = ({
     send("UPDATE_ALL_SECTION_NUMBERS", initialLayoutPlan);
   }, [initialLayoutPlan, send]);
 
-  useEffect(() => {
-    /**Sections in a slot is changed, so notify parent**/
-    if (sectionChangeClicked.current) {
-      onPlanLayoutChange(layoutPlan);
-      sectionChangeClicked.current = false;
-    }
-  }, [layoutPlan, onPlanLayoutChange]);
-
   const rowClassnames = classNames(
     {
       "opacity-50": cancelled,
@@ -139,9 +121,8 @@ const TubeRow: React.FC<TubeRowProps> = ({
   );
 
   const handleOnClick = useCallback(() => {
-    onPlanCancelled(layoutPlan, !cancelled);
     send({ type: "TOGGLE_CANCEL" });
-  }, [send, onPlanCancelled, cancelled, layoutPlan]);
+  }, [send]);
 
   const handleOnChange = useCallback(
     (slotAddress: string, sectionNumber: number, sectionIndex: number) => {

--- a/src/components/sectioningConfirm/ConfirmTubes.tsx
+++ b/src/components/sectioningConfirm/ConfirmTubes.tsx
@@ -223,6 +223,7 @@ const TubeRow: React.FC<TubeRowProps> = ({
         {layoutPlan.plannedActions.get("A1")?.map((source, index) => (
           <Input
             key={source.address + String(index)}
+            data-testid={`sectionnumber-tube-${layoutPlan.destinationLabware.barcode}`}
             type="number"
             value={source.newSection === 0 ? "" : String(source.newSection)}
             min={1}
@@ -236,7 +237,10 @@ const TubeRow: React.FC<TubeRowProps> = ({
         ))}
       </TableCell>
       <TableCell onClick={handleOnClick}>
-        <RemoveIcon className="h-4 w-4 text-red-500" />
+        <RemoveIcon
+          data-testid={`remove-tube-${layoutPlan.destinationLabware.barcode}`}
+          className="h-4 w-4 text-red-500"
+        />
       </TableCell>
     </tr>
   );

--- a/src/components/sectioningConfirm/ConfirmTubes.tsx
+++ b/src/components/sectioningConfirm/ConfirmTubes.tsx
@@ -18,13 +18,20 @@ import BlueButton from "../buttons/BlueButton";
 import WhiteButton from "../buttons/WhiteButton";
 import PinkButton from "../buttons/PinkButton";
 import Labware from "../labware/Labware";
-import { CommentFieldsFragment, ConfirmSectionLabware } from "../../types/sdk";
+import {
+  CommentFieldsFragment,
+  ConfirmSectionLabware,
+  LabwareFieldsFragment,
+} from "../../types/sdk";
 import { selectConfirmOperationLabware } from "./index";
 
 interface ConfirmTubesProps {
   layoutPlans: Array<LayoutPlan>;
   comments: Array<CommentFieldsFragment>;
-  onChange: (labware: ConfirmSectionLabware) => void;
+  onChange: (
+    labware: ConfirmSectionLabware,
+    sourceLabwares: LabwareFieldsFragment[]
+  ) => void;
   disableSectionNumbers?: boolean;
 }
 
@@ -76,7 +83,10 @@ export default ConfirmTubes;
 interface TubeRowProps {
   initialLayoutPlan: LayoutPlan;
   comments: Array<CommentFieldsFragment>;
-  onChange: (labware: ConfirmSectionLabware) => void;
+  onChange: (
+    labware: ConfirmSectionLabware,
+    sourceLabwares: LabwareFieldsFragment[]
+  ) => void;
   disableSectionNumbers?: boolean;
 }
 
@@ -103,9 +113,14 @@ const TubeRow: React.FC<TubeRowProps> = ({
 
   useEffect(() => {
     if (confirmOperationLabware) {
-      onChange(confirmOperationLabware);
+      onChange(
+        confirmOperationLabware,
+        Array.from(layoutPlan.plannedActions.values()).flatMap((sources) =>
+          Array.from(sources.values()).map((source) => source.labware)
+        )
+      );
     }
-  }, [onChange, confirmOperationLabware]);
+  }, [onChange, confirmOperationLabware, layoutPlan.plannedActions]);
 
   /**Update for section numbers changes in parent**/
   useEffect(() => {

--- a/src/components/sectioningConfirm/ConfirmTubes.tsx
+++ b/src/components/sectioningConfirm/ConfirmTubes.tsx
@@ -25,12 +25,15 @@ interface ConfirmTubesProps {
   layoutPlans: Array<LayoutPlan>;
   comments: Array<CommentFieldsFragment>;
   onChange: (labware: ConfirmSectionLabware) => void;
+  disableSectionNumbers?: boolean;
 }
 
 const ConfirmTubes: React.FC<ConfirmTubesProps> = ({
   layoutPlans,
   comments,
   onChange,
+
+  disableSectionNumbers = false,
 }) => {
   return (
     <div className="p-4 lg:w-2/3 lg:mx-auto rounded-lg bg-gray-100 space-y-4">
@@ -59,6 +62,7 @@ const ConfirmTubes: React.FC<ConfirmTubesProps> = ({
                 initialLayoutPlan={layoutPlan}
                 comments={comments}
                 onChange={onChange}
+                disableSectionNumbers={disableSectionNumbers}
               />
             ))}
           </TableBody>
@@ -74,12 +78,14 @@ interface TubeRowProps {
   initialLayoutPlan: LayoutPlan;
   comments: Array<CommentFieldsFragment>;
   onChange: (labware: ConfirmSectionLabware) => void;
+  disableSectionNumbers?: boolean;
 }
 
 const TubeRow: React.FC<TubeRowProps> = ({
   initialLayoutPlan,
   comments,
   onChange,
+  disableSectionNumbers = false,
 }) => {
   const [current, send, service] = useMachine(
     createConfirmLabwareMachine(
@@ -99,6 +105,10 @@ const TubeRow: React.FC<TubeRowProps> = ({
       onChange(confirmOperationLabware);
     }
   }, [onChange, confirmOperationLabware]);
+
+  useEffect(() => {
+    send("UPDATE_ALL_SECTION_NUMBERS", initialLayoutPlan);
+  }, [initialLayoutPlan, send]);
 
   const { cancelled, layoutPlan, labware } = current.context;
   const { layoutMachine } = current.children;
@@ -197,11 +207,9 @@ const TubeRow: React.FC<TubeRowProps> = ({
           <Input
             key={source.address + String(index)}
             type="number"
-            defaultValue={
-              source.newSection === 0 ? "" : String(source.newSection)
-            }
+            value={source.newSection === 0 ? "" : String(source.newSection)}
             min={1}
-            disabled={cancelled}
+            disabled={cancelled || disableSectionNumbers}
             // So the row click handler doesn't get triggered
             onClick={(e) => e.stopPropagation()}
             onChange={(e) =>

--- a/src/components/sectioningConfirm/ConfirmTubes.tsx
+++ b/src/components/sectioningConfirm/ConfirmTubes.tsx
@@ -95,7 +95,6 @@ const TubeRow: React.FC<TubeRowProps> = ({
   );
   const { cancelled, layoutPlan, labware } = current.context;
   const { layoutMachine } = current.children;
-  const sectionChangeClicked = React.useRef<boolean>(false);
 
   const confirmOperationLabware = useSelector(
     service,
@@ -124,6 +123,7 @@ const TubeRow: React.FC<TubeRowProps> = ({
     send({ type: "TOGGLE_CANCEL" });
   }, [send]);
 
+  /***Update section numbers whenever there is an update in section numbers in parent**/
   const handleOnChange = useCallback(
     (slotAddress: string, sectionNumber: number, sectionIndex: number) => {
       send({
@@ -188,7 +188,6 @@ const TubeRow: React.FC<TubeRowProps> = ({
             <ModalFooter>
               <BlueButton
                 onClick={() => {
-                  sectionChangeClicked.current = true;
                   layoutMachine.send({ type: "DONE" });
                 }}
                 className="w-full text-base sm:ml-3 sm:w-auto sm:text-sm"

--- a/src/components/sectioningConfirm/LabwareComments.tsx
+++ b/src/components/sectioningConfirm/LabwareComments.tsx
@@ -11,7 +11,8 @@ interface LabwareCommentsProps {
   layoutPlan: LayoutPlan;
   comments: Array<Comment>;
   value: string | number | undefined;
-  disabled?: boolean;
+  disabledComment?: boolean;
+  disabledSectionNumber?: boolean;
   onCommentChange: (e: ChangeEvent<HTMLSelectElement>) => void;
   onSectionNumberChange: (
     slotAddress: string,
@@ -26,7 +27,8 @@ const LabwareComments: React.FC<LabwareCommentsProps> = ({
   comments,
   value,
   onCommentChange,
-  disabled = false,
+  disabledComment = false,
+  disabledSectionNumber = false,
   onSectionNumberChange,
 }) => {
   return (
@@ -39,10 +41,9 @@ const LabwareComments: React.FC<LabwareCommentsProps> = ({
           <Input
             key={source.address + String(index)}
             type="number"
-            defaultValue={
-              source.newSection === 0 ? "" : String(source.newSection)
-            }
+            value={source.newSection === 0 ? "" : String(source.newSection)}
             min={1}
+            disabled={disabledSectionNumber}
             onChange={(e) =>
               onSectionNumberChange(slot.address, index, Number(e.target.value))
             }
@@ -56,7 +57,7 @@ const LabwareComments: React.FC<LabwareCommentsProps> = ({
         {layoutPlan.plannedActions.has(slot.address) && (
           <Select
             value={value}
-            disabled={disabled}
+            disabled={disabledComment}
             style={{ width: "100%" }}
             onChange={(e) => onCommentChange(e)}
           >

--- a/src/components/sectioningConfirm/SectioningConfirm.tsx
+++ b/src/components/sectioningConfirm/SectioningConfirm.tsx
@@ -102,10 +102,11 @@ export default function SectioningConfirm({
    * e.g. sections are added, comments are made against sections
    */
   const handleConfirmChange = useCallback(
-    (confirmSectionLabware) => {
+    (confirmSectionLabware, sourceLabwares: LabwareFieldsFragment[]) => {
       send({
         type: "UPDATE_CONFIRM_SECTION_LABWARE",
         confirmSectionLabware,
+        sourceLabwares,
       });
     },
     [send]

--- a/src/components/sectioningConfirm/SectioningConfirm.tsx
+++ b/src/components/sectioningConfirm/SectioningConfirm.tsx
@@ -18,7 +18,6 @@ import Warning from "../notifications/Warning";
 import WorkNumberSelect from "../WorkNumberSelect";
 import RadioGroup, { RadioButtonInput } from "../forms/RadioGroup";
 import { objectKeys } from "../../lib/helpers";
-import { LayoutPlan } from "../../lib/machines/layout/layoutContext";
 import { ConfirmationModal } from "../modal/ConfirmationModal";
 
 type SectioningConfirmProps = {
@@ -99,22 +98,18 @@ export default function SectioningConfirm({
   );
 
   /**
-   * Callback for when the {@link LayoutPlan} updates its section layout
-   */
-  const handlePlanLayoutChange = useCallback(
-    (layoutPlan: LayoutPlan) => {
-      send({ type: "UPDATE_SECTIONLAYOUT_IN_PLAN", layoutPlan });
-    },
-    [send]
-  );
-
-  /**
    * Callback for when a {@link ConfirmLabware} or {@link ConfirmTubes} updates
    * e.g. sections are added, comments are made against sections
    */
   const handleConfirmChange = useCallback(
     (confirmSectionLabware) => {
-      send({ type: "UPDATE_CONFIRM_SECTION_LABWARE", confirmSectionLabware });
+      send({
+        type: "UPDATE_CONFIRM_SECTION_LABWARE",
+        confirmSectionLabware,
+        labware: sourceLabware.find(
+          (lw) => lw.barcode === confirmSectionLabware.barcode
+        ),
+      });
     },
     [send]
   );
@@ -126,25 +121,15 @@ export default function SectioningConfirm({
     [send]
   );
 
-  const handlePlanCancelled = useCallback(
-    (layoutPlan: LayoutPlan, cancelled: boolean) => {
-      debugger;
-      send({ type: "UPDATE_CANCELLED_LAYOUTPLAN", layoutPlan, cancelled });
-    },
-    [send]
-  );
-
   const handleDeleteLabwarePlan = useCallback(
     (labwareBarcode: string, deleteLabwarePlan: (barcode: string) => void) => {
-      //&&
-      //         Object.values(layoutPlansByLabwareType).length > 1
       if (sectionNumberMode === SectionNumberMode.Auto) {
         setLabwarePlanToDelete(labwareBarcode);
       } else {
         deleteLabwarePlan(labwareBarcode);
       }
     },
-    [setLabwarePlanToDelete, sectionNumberMode, layoutPlansByLabwareType]
+    [setLabwarePlanToDelete, sectionNumberMode]
   );
 
   return (
@@ -230,8 +215,6 @@ export default function SectioningConfirm({
                       disableSectionNumbers={
                         sectionNumberMode === SectionNumberMode.Auto
                       }
-                      onPlanLayoutChange={handlePlanLayoutChange}
-                      onPlanCancelled={handlePlanCancelled}
                     />
                   )}
 
@@ -249,7 +232,6 @@ export default function SectioningConfirm({
                           {lps.map((layoutPlan) => (
                             <ConfirmLabware
                               onChange={handleConfirmChange}
-                              onPlanLayoutChange={handlePlanLayoutChange}
                               onRemoveClick={(labwareBarcode) => {
                                 handleDeleteLabwarePlan(
                                   labwareBarcode,

--- a/src/components/sectioningConfirm/SectioningConfirm.tsx
+++ b/src/components/sectioningConfirm/SectioningConfirm.tsx
@@ -106,14 +106,14 @@ export default function SectioningConfirm({
       send({
         type: "UPDATE_CONFIRM_SECTION_LABWARE",
         confirmSectionLabware,
-        labware: sourceLabware.find(
-          (lw) => lw.barcode === confirmSectionLabware.barcode
-        ),
       });
     },
     [send]
   );
 
+  /**
+   * Callback to handle change in section numbering mode
+   */
   const handleSectionNumberingModeChange = useCallback(
     (mode: SectionNumberMode) => {
       send({ type: "UPDATE_SECTION_NUMBERING_MODE", mode });
@@ -121,6 +121,9 @@ export default function SectioningConfirm({
     [send]
   );
 
+  /**
+   * Callback to handle deleting labware plan
+   */
   const handleDeleteLabwarePlan = useCallback(
     (labwareBarcode: string, deleteLabwarePlan: (barcode: string) => void) => {
       if (sectionNumberMode === SectionNumberMode.Auto) {
@@ -181,10 +184,10 @@ export default function SectioningConfirm({
                         name={"sectionNumber"}
                         withFormik={false}
                       >
-                        {objectKeys(SectionNumberMode).map((key, index) => {
+                        {objectKeys(SectionNumberMode).map((key) => {
                           return (
                             <RadioButtonInput
-                              key={index}
+                              key={key}
                               name={"sectionNumber"}
                               value={SectionNumberMode[key]}
                               checked={
@@ -294,8 +297,8 @@ export default function SectioningConfirm({
                   ]}
                 >
                   <p className={"font-bold mt-8"}>
-                    Section numbers in all remaining labware will be auto
-                    numbered with deletion.
+                    Section numbers in all remaining labware will be updated
+                    with deletion.
                   </p>
                 </ConfirmationModal>
               </div>

--- a/src/components/sectioningConfirm/SectioningConfirm.tsx
+++ b/src/components/sectioningConfirm/SectioningConfirm.tsx
@@ -19,6 +19,7 @@ import WorkNumberSelect from "../WorkNumberSelect";
 import RadioGroup, { RadioButtonInput } from "../forms/RadioGroup";
 import { objectKeys } from "../../lib/helpers";
 import { ConfirmationModal } from "../modal/ConfirmationModal";
+import { LayoutPlan } from "../../lib/machines/layout/layoutContext";
 
 type SectioningConfirmProps = {
   /**
@@ -62,7 +63,7 @@ export default function SectioningConfirm({
   } = current.context;
 
   const [labwarePlanToDelete, setLabwarePlanToDelete] = React.useState<
-    string | undefined
+    LayoutPlan | undefined
   >(undefined);
 
   /**
@@ -126,11 +127,11 @@ export default function SectioningConfirm({
    * Callback to handle deleting labware plan
    */
   const handleDeleteLabwarePlan = useCallback(
-    (labwareBarcode: string, deleteLabwarePlan: (barcode: string) => void) => {
+    (layoutPlan: LayoutPlan, deleteLabwarePlan: (barcode: string) => void) => {
       if (sectionNumberMode === SectionNumberMode.Auto) {
-        setLabwarePlanToDelete(labwareBarcode);
+        setLabwarePlanToDelete(layoutPlan);
       } else {
-        deleteLabwarePlan(labwareBarcode);
+        deleteLabwarePlan(layoutPlan.destinationLabware.barcode!);
       }
     },
     [setLabwarePlanToDelete, sectionNumberMode]
@@ -174,12 +175,8 @@ export default function SectioningConfirm({
                       />
                     </div>
 
-                    <Heading level={3}>Section Numbering</Heading>
-                    <div
-                      className={
-                        "md:w-1/2 flex flex-row sm:justify-between px-3"
-                      }
-                    >
+                    <div className={"sm:justify-between px-3"}>
+                      <Heading level={3}>Section Numbering</Heading>
                       <RadioGroup
                         label="Select mode"
                         name={"sectionNumber"}
@@ -291,15 +288,18 @@ export default function SectioningConfirm({
                       label: "Continue",
                       action: () => {
                         labwarePlanToDelete &&
-                          removePlanByBarcode(labwarePlanToDelete);
+                          labwarePlanToDelete.destinationLabware.barcode &&
+                          removePlanByBarcode(
+                            labwarePlanToDelete.destinationLabware.barcode
+                          );
                         setLabwarePlanToDelete(undefined);
                       },
                     },
                   ]}
                 >
                   <p className={"font-bold mt-8"}>
-                    Section numbers in all remaining labware will be updated
-                    with deletion.
+                    Section numbers of remaining plans with same source labware
+                    will be renumbered with deletion.
                   </p>
                 </ConfirmationModal>
               </div>

--- a/src/components/sectioningConfirm/confirmLabware.machine.ts
+++ b/src/components/sectioningConfirm/confirmLabware.machine.ts
@@ -11,6 +11,7 @@ import { assign } from "@xstate/immer";
 import { createLayoutMachine } from "../../lib/machines/layout/layoutMachine";
 import { cloneDeep } from "lodash";
 import { Address, NewLabwareLayout } from "../../types/stan";
+import { SectionNumberMode } from "./SectioningConfirm";
 
 export interface ConfirmLabwareContext {
   /**
@@ -80,6 +81,15 @@ type UpdateAllSectionNumbersEvent = {
   plannedActions: Map<Address, Array<Source>>;
 };
 
+type UpdateSectionNumberModeEvent = {
+  type: "UPDATE_SECTION_NUMBER_MODE";
+  mode: SectionNumberMode;
+};
+type SetMinimumSectionNumberEvent = {
+  type: "SET_MIN_SECTION_NUMBER";
+  minSectionNumber: number;
+};
+
 export type CommitConfirmationEvent = {
   type: "COMMIT_CONFIRMATION";
   confirmOperationLabware: ConfirmOperationLabware;
@@ -99,6 +109,8 @@ export type ConfirmLabwareEvent =
   | ToggleCancelEvent
   | UpdateSectionNumberEvent
   | UpdateAllSectionNumbersEvent
+  | UpdateSectionNumberModeEvent
+  | SetMinimumSectionNumberEvent
   | CommitConfirmationEvent
   | SectioningConfirmationCompleteEvent;
 
@@ -167,6 +179,9 @@ export const createConfirmLabwareMachine = (
             },
             UPDATE_ALL_SECTION_NUMBERS: {
               actions: ["updateAllSectionNumbers", "commitConfirmation"],
+            },
+            SET_MIN_SECTION_NUMBER: {
+              actions: ["setMinimumSectionNumber", "commmitConfirmation"],
             },
           },
         },
@@ -267,14 +282,21 @@ export const createConfirmLabwareMachine = (
           }
           for (let [key, sources] of e.plannedActions.entries()) {
             const currentSources = ctx.layoutPlan.plannedActions.get(key);
-            sources.forEach((source) => {
-              const currSource = currentSources
-                ? currentSources.find((sc) => source.address === sc.address)
-                : undefined;
-              if (currSource) {
-                currSource.newSection = source.newSection;
-              }
-            });
+            debugger;
+
+            sources &&
+              sources.forEach((source, indx) => {
+                debugger;
+                const currSourcesForAddress = currentSources
+                  ? currentSources.filter((sc) => source.address === sc.address)
+                  : undefined;
+                if (
+                  currSourcesForAddress &&
+                  currSourcesForAddress.length > indx
+                ) {
+                  currSourcesForAddress[indx].newSection = source.newSection;
+                }
+              });
           }
         }),
         commitConfirmation: assign((ctx) => {

--- a/src/components/sectioningConfirm/confirmLabware.machine.ts
+++ b/src/components/sectioningConfirm/confirmLabware.machine.ts
@@ -266,7 +266,6 @@ export const createConfirmLabwareMachine = (
           if (e.type !== "UPDATE_SECTION_NUMBER") {
             return;
           }
-
           const plannedAction = ctx.layoutPlan.plannedActions.get(
             e.slotAddress
           );
@@ -282,11 +281,8 @@ export const createConfirmLabwareMachine = (
           }
           for (let [key, sources] of e.plannedActions.entries()) {
             const currentSources = ctx.layoutPlan.plannedActions.get(key);
-            debugger;
-
             sources &&
               sources.forEach((source, indx) => {
-                debugger;
                 const currSourcesForAddress = currentSources
                   ? currentSources.filter((sc) => source.address === sc.address)
                   : undefined;
@@ -301,7 +297,6 @@ export const createConfirmLabwareMachine = (
         }),
         commitConfirmation: assign((ctx) => {
           const confirmSections: Array<ConfirmSection> = [];
-
           for (let [
             destinationAddress,
             originalPlannedActions,

--- a/src/mocks/handlers/planHandlers.ts
+++ b/src/mocks/handlers/planHandlers.ts
@@ -1,9 +1,10 @@
-import { graphql } from "msw";
+import { graphql, GraphQLContext } from "msw";
 import {
   ConfirmMutation,
   ConfirmMutationVariables,
   FindPlanDataQuery,
   FindPlanDataQueryVariables,
+  Labware,
   PlanMutation,
   PlanMutationVariables,
 } from "../../types/sdk";
@@ -118,45 +119,7 @@ const planHandlers = [
         }
       );
 
-      return res(
-        ctx.data({
-          planData: {
-            sources: [buildLabwareFragment(sourceLabware)],
-            destination: buildLabwareFragment(destinationLabware),
-            plan: {
-              operationType: {
-                __typename: "OperationType",
-                name: "Section",
-              },
-              planActions: [
-                {
-                  __typename: "PlanAction",
-                  source: {
-                    __typename: "Slot",
-                    address: "A1",
-                    samples: [
-                      {
-                        __typename: "Sample",
-                        id: sourceLabware.slots[0].samples[0].id,
-                      },
-                    ],
-                    labwareId: sourceLabware.id,
-                  },
-                  destination: {
-                    __typename: "Slot",
-                    labwareId: destinationLabware.id,
-                    address: "A1",
-                  },
-                  sample: {
-                    __typename: "Sample",
-                    id: sourceLabware.slots[0].samples[0].id,
-                  },
-                },
-              ],
-            },
-          },
-        })
-      );
+      return res(findPlanData(sourceLabware, destinationLabware, ctx));
     }
   ),
 
@@ -174,5 +137,49 @@ const planHandlers = [
     }
   ),
 ];
+
+export function findPlanData(
+  sourceLabware: Labware,
+  destinationLabware: Labware,
+  ctx: GraphQLContext<FindPlanDataQuery>
+) {
+  return ctx.data({
+    planData: {
+      sources: [buildLabwareFragment(sourceLabware)],
+      destination: buildLabwareFragment(destinationLabware),
+      plan: {
+        operationType: {
+          __typename: "OperationType",
+          name: "Section",
+        },
+        planActions: [
+          {
+            __typename: "PlanAction",
+            source: {
+              __typename: "Slot",
+              address: "A1",
+              samples: [
+                {
+                  __typename: "Sample",
+                  id: sourceLabware.slots[0].samples[0].id,
+                },
+              ],
+              labwareId: sourceLabware.id,
+            },
+            destination: {
+              __typename: "Slot",
+              labwareId: destinationLabware.id,
+              address: "A1",
+            },
+            sample: {
+              __typename: "Sample",
+              id: sourceLabware.slots[0].samples[0].id,
+            },
+          },
+        ],
+      },
+    },
+  });
+}
 
 export default planHandlers;


### PR DESCRIPTION
Auto numbering option for section numbers
- Option to switch between Auto and Manual
- Default option is 'Auto'
- In 'Auto mode, 
        - All section numbers will be numbered starting from highest section number for the source
        - All section number fields will be disabled
        - Adding/Deleting new sections updates the section numbers automatically
        - If a Tube is cancelled, section numbers will be removed from the cancelled ones and all other labware for that source will be re-numbered
        - If any labware other than Tube is deleted,  a warning will be given about renumbering of section numbers 