### PR TITLE
X838 dual index plate

### DIFF
--- a/cypress/integration/pages/dualIndexPlateSpec.ts
+++ b/cypress/integration/pages/dualIndexPlateSpec.ts
@@ -187,7 +187,15 @@ describe("Dual Index Plate", () => {
       });
       it("should display a success message", () => {
         cy.findByText("Reagents transferred").should("be.visible");
+      });
+      it("should display Reset button", () => {
         cy.findByRole("button", { name: /Reset Form/i }).should("be.visible");
+      });
+      it("should disable Clear button", () => {
+        cy.findByRole("button", { name: /Clear/i }).should("be.disabled");
+      });
+      it("should disable Remove button", () => {
+        cy.findAllByTestId("removeButton").eq(0).should("be.disabled");
       });
     });
   });

--- a/cypress/integration/pages/dualIndexPlateSpec.ts
+++ b/cypress/integration/pages/dualIndexPlateSpec.ts
@@ -91,14 +91,42 @@ describe("Dual Index Plate", () => {
         );
       });
     });
-    context("when user clears the mapped slot", () => {
+  });
+  describe("On removing mapping", () => {
+    before(() => {
+      cy.get("#sourceLabwares").within(() => {
+        cy.findByText("A3").click();
+      });
+      cy.get("#destLabwares").within(() => {
+        cy.findByText("A3").click();
+      });
+    });
+    it("should display two mappings in table", () => {
+      //find("tr) return rows including header
+      cy.findByRole("table").find("tr").should("have.length", 3);
+    });
+    context("when user clicks remove button in the mapping table", () => {
       before(() => {
+        cy.findAllByTestId("removeButton").eq(0).click();
+      });
+      it("should remove the mapping", () => {
+        cy.findByRole("table")
+          .find("tr")
+          .contains("td", "A1")
+          .should("not.exist");
+      });
+    });
+    context("when user clears all mapped slots", () => {
+      before(() => {
+        cy.get("#sourceLabwares").within(() => {
+          cy.findByText("A3").click();
+        });
         cy.get("#destLabwares").within(() => {
-          cy.findByText("A1").click();
+          cy.findByText("A3").click();
         });
         cy.findByRole("button", { name: /Clear/i }).click();
       });
-      it("should remove the mapping", () => {
+      it("should remove all mappings", () => {
         cy.findByRole("table").should("not.exist");
       });
       it("should not enable Save button", () => {
@@ -114,16 +142,16 @@ describe("Dual Index Plate", () => {
       });
     });
   });
-  context("When user selects a work number and have a mapping", () => {
-    before(() => {
-      cy.get("select").select("SGP1008");
-    });
-    it("should enable save", () => {
-      saveButton().should("be.enabled");
-    });
-  });
 
   describe("On Save", () => {
+    context("When user selects a work number and have a mapping", () => {
+      before(() => {
+        cy.get("select").select("SGP1008");
+      });
+      it("should enable save", () => {
+        saveButton().should("be.enabled");
+      });
+    });
     context("when there is a server error", () => {
       before(() => {
         cy.msw().then(({ worker, graphql }) => {

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -254,6 +254,16 @@ function AppShell({ children }: AppShellParams) {
                         "Select the best permeabilisation time for a slide."
                       }
                     />
+                    <NavLinkMenuItem
+                      caption={"Dual Index Plate"}
+                      path={"/lab/dual_index_plate"}
+                      icon={
+                        <LabwareIcon className="flex-shrink-0 h-6 w-6 text-sdb-400" />
+                      }
+                      description={
+                        "Record the transfer of dual-index reagent to 96 well plate."
+                      }
+                    />
                   </Menu>
                   <NavLinkMenuItem
                     caption={"Imaging"}
@@ -480,6 +490,9 @@ function AppShell({ children }: AppShellParams) {
                       </StanMobileNavLink>
                       <StanMobileNavLink to="/lab/visium_analysis">
                         Visium Analysis
+                      </StanMobileNavLink>
+                      <StanMobileNavLink to="/lab/dual_index_plate">
+                        Dual Index Plate
                       </StanMobileNavLink>
                     </div>
                     <div className="grid grid-cols-2 ml-2 gap-y-4 gap-x-8">

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -35,7 +35,6 @@ import VisiumQC from "../pages/VisiumQC";
 import VisiumPerm from "../pages/VisiumPerm";
 import VisiumAnalysis from "../pages/VisiumAnalysis";
 import Aliquot from "../pages/Aliquot";
-import ReagentTransfer from "../pages/DualIndexPlate";
 import DualIndexPlate from "../pages/DualIndexPlate";
 
 export function Routes() {

--- a/src/components/Routes.tsx
+++ b/src/components/Routes.tsx
@@ -35,6 +35,8 @@ import VisiumQC from "../pages/VisiumQC";
 import VisiumPerm from "../pages/VisiumPerm";
 import VisiumAnalysis from "../pages/VisiumAnalysis";
 import Aliquot from "../pages/Aliquot";
+import ReagentTransfer from "../pages/DualIndexPlate";
+import DualIndexPlate from "../pages/DualIndexPlate";
 
 export function Routes() {
   const stanCore = useContext(StanCoreContext);
@@ -143,6 +145,12 @@ export function Routes() {
         path="/lab/visium_analysis"
         render={(routeProps) => (
           <VisiumAnalysis key={routeProps.location.key} />
+        )}
+      />
+      <AuthenticatedRoute
+        path="/lab/dual_index_plate"
+        render={(routeProps) => (
+          <DualIndexPlate key={routeProps.location.key} />
         )}
       />
 

--- a/src/components/buttons/RemoveButton.tsx
+++ b/src/components/buttons/RemoveButton.tsx
@@ -12,7 +12,7 @@ const RemoveButton: React.FC<RemoveButtonProps> = (props) => {
     <button
       data-testid="removeButton"
       {...props}
-      className="inline-flex items-center justify-center p-2 rounded-md hover:bg-red-100 focus:outline-none focus:bg-red-100 text-red-400 hover:text-red-600"
+      className="inline-flex items-center justify-center p-2 rounded-md hover:bg-red-100 focus:outline-none focus:bg-red-100 text-red-400 hover:text-red-600 disabled:text-gray-200"
     >
       <RemoveIcon className="block h-5 w-5" />
     </button>

--- a/src/components/slotMapper/ReagentTransferSlotMapper.tsx
+++ b/src/components/slotMapper/ReagentTransferSlotMapper.tsx
@@ -18,6 +18,9 @@ import { find } from "lodash";
 import { findSlotByAddress, isSlotEmpty } from "../../lib/helpers/slotHelper";
 import { toast } from "react-toastify";
 import warningToast from "../notifications/WarningToast";
+import Heading from "../Heading";
+import Table, { TableBody, TableCell, TableHead, TableHeader } from "../Table";
+import RemoveButton from "../buttons/RemoveButton";
 
 export interface ReagentTransferMappingProps {
   /**
@@ -215,11 +218,25 @@ function ReagentTransferSlotMapper({
       send({
         type: "CLEAR_SLOTS",
         outputLabwareId: initialDestLabware.id,
-        outputAddresses: selectedOutputAddresses,
+        outputAddresses: slotCopyContent.map((scc) => scc.destinationAddress),
       });
       outputLabwareRef.current?.deselectAll();
     }
-  }, [send, initialDestLabware, selectedOutputAddresses, outputLabwareRef]);
+  }, [send, initialDestLabware, outputLabwareRef, slotCopyContent]);
+
+  const handleOnRemoveMapping = React.useCallback(
+    (destAddress: string) => {
+      send({
+        type: "CLEAR_SLOTS",
+        outputLabwareId: initialDestLabware!.id,
+        outputAddresses: [destAddress],
+      });
+      if (selectedOutputAddresses.includes(destAddress)) {
+        outputLabwareRef.current?.deselectAll();
+      }
+    },
+    [initialDestLabware, outputLabwareRef, selectedOutputAddresses, send]
+  );
 
   /**
    * Whenever the SlotCopyContent map changes, or the current input labware changes,
@@ -237,7 +254,7 @@ function ReagentTransferSlotMapper({
   }, [onChange, slotCopyContent, anySourceMapped]);
 
   return (
-    <div className="space-y-8 mt-3 ">
+    <div className="mt-3 space-y-8">
       <div className="grid grid-cols-2 auto-rows-auto">
         <div id="sourceLabwares" className="bg-gray-100">
           {initialSourceLabware && (
@@ -272,6 +289,35 @@ function ReagentTransferSlotMapper({
           )}
         </div>
       </div>
+      {slotCopyContent.length > 0 && (
+        <div className="flex flex-col p-4 bg-gray-100 space-y-8">
+          <Heading level={4}>Mapping</Heading>
+          <Table>
+            <TableHead>
+              <tr>
+                <TableHeader>Source - Dual index plate</TableHeader>
+                <TableHeader>Destination - 96 well plate</TableHeader>
+              </tr>
+            </TableHead>
+            <TableBody>
+              {slotCopyContent.map((scc) => (
+                <tr key={scc.sourceBarcode + scc.sourceAddress}>
+                  <TableCell>{scc.sourceAddress}</TableCell>
+                  <TableCell>{scc.destinationAddress}</TableCell>
+                  <TableCell>
+                    <RemoveButton
+                      type="button"
+                      onClick={() =>
+                        handleOnRemoveMapping(scc.destinationAddress)
+                      }
+                    />
+                  </TableCell>
+                </tr>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
       {initialSourceLabware && initialDestLabware && (
         <div className="border-gray-300 border-t-2 p-4 flex flex-row items-center justify-end bg-gray-200">
           <WhiteButton onClick={handleOnClickClear}>Clear</WhiteButton>

--- a/src/components/slotMapper/ReagentTransferSlotMapper.tsx
+++ b/src/components/slotMapper/ReagentTransferSlotMapper.tsx
@@ -1,0 +1,265 @@
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Labware, { LabwareImperativeRef } from "../labware/Labware";
+import slotMapperMachine from "./slotMapper.machine";
+import WhiteButton from "../buttons/WhiteButton";
+import {
+  LabwareFieldsFragment,
+  SlotCopyContent,
+  SlotFieldsFragment,
+} from "../../types/sdk";
+import { NewLabwareLayout } from "../../types/stan";
+import { useMachine } from "@xstate/react";
+import { find } from "lodash";
+
+export interface ReagentTransferMappingProps {
+  /**
+   * Callback that's called whenever a slot is mapped or unmapped
+   *
+   * @param slotCopyContent the current mapping of source to destination slots
+   * @param allSourcesMapped true if input labware exists and their non-empty slots have been mapped, false otherwise
+   */
+  onChange?: (
+    slotCopyContent: Array<SlotCopyContent>,
+    allSourcesMapped: boolean
+  ) => void;
+
+  /**
+   * Lock the SlotMapper.
+   */
+  locked?: boolean;
+
+  /**
+   * Initial input labware
+   */
+  initialSourceLabware: LabwareFieldsFragment | undefined;
+
+  /**
+   * Initial output labware
+   */
+  initialDestLabware: LabwareFieldsFragment | undefined;
+}
+
+function ReagentTransferSlotMapper({
+  onChange,
+  initialSourceLabware,
+  initialDestLabware,
+}: ReagentTransferMappingProps) {
+  const [current, send] = useMachine(() =>
+    slotMapperMachine.withContext({
+      inputLabware: initialSourceLabware ? [initialSourceLabware] : [],
+      outputLabware: initialDestLabware ? [initialDestLabware] : [],
+      slotCopyContent: [],
+      colorByBarcode: new Map(),
+      failedSlots: new Map(),
+      errors: new Map(),
+    })
+  );
+
+  const { slotCopyContent, colorByBarcode } = current.context;
+  /**
+   * Update machine state when inut/source labware is changed in parent
+   */
+  React.useEffect(() => {
+    if (!initialSourceLabware) return;
+    send({ type: "UPDATE_INPUT_LABWARE", labware: [initialSourceLabware] });
+  }, [send, initialSourceLabware]);
+
+  /**
+   * Update machine state when output/destination labware is changed in parent
+   */
+  React.useEffect(() => {
+    if (!initialDestLabware) return;
+    send({ type: "UPDATE_OUTPUT_LABWARE", labware: [initialDestLabware] });
+  }, [send, initialDestLabware]);
+
+  const anySourceMapped = useMemo(() => {
+    if (!initialSourceLabware || !initialDestLabware) {
+      return false;
+    }
+    return slotCopyContent.length > 0;
+  }, [slotCopyContent, initialSourceLabware, initialDestLabware]);
+
+  const getSourceSlotColor = useCallback(
+    (
+      labware: LabwareFieldsFragment,
+      address: string,
+      slot: SlotFieldsFragment
+    ) => {
+      if (
+        find(slotCopyContent, {
+          sourceBarcode: labware.barcode,
+          sourceAddress: address,
+        })
+      ) {
+        return `bg-red-200`;
+      }
+
+      if (slot?.samples?.length) {
+        return `bg-red-500`;
+      }
+    },
+    [slotCopyContent, colorByBarcode]
+  );
+
+  const getDestinationSlotColor = useCallback(
+    (labware: NewLabwareLayout, address: string) => {
+      const scc = find(slotCopyContent, {
+        destinationAddress: address,
+      });
+
+      if (scc) {
+        return `bg-green-500`;
+      }
+    },
+    [slotCopyContent, colorByBarcode]
+  );
+
+  /**
+   * State to track the currently selected input and output addresses
+   */
+  const [selectedInputAddresses, setSelectedInputAddresses] = useState<
+    Array<string>
+  >([]);
+  const [selectedOutputAddresses, setSelectedOutputAddresses] = useState<
+    Array<string>
+  >([]);
+
+  /**
+   * State to keep the output address clicked to transfer from input
+   */
+  const [destinationAddress, setDestinationAddress] = useState<
+    string | undefined
+  >();
+
+  /**
+   * These refs are passed into the Labware components so we can imperatively
+   * change their state e.g. deselecting all slots
+   */
+  const inputLabwareRef = useRef<LabwareImperativeRef>(null);
+  const outputLabwareRef = useRef<LabwareImperativeRef>(null);
+
+  /**
+   * Callback for sending the actual copy slots event
+   */
+  const handleCopySlots = React.useCallback(
+    (givenDestinationAddress?: string) => {
+      if (!initialSourceLabware || !initialDestLabware) return;
+      const address = destinationAddress
+        ? destinationAddress
+        : givenDestinationAddress;
+      if (
+        initialSourceLabware.barcode &&
+        initialDestLabware.barcode &&
+        address
+      ) {
+        send({
+          type: "COPY_SLOTS",
+          inputLabwareId: initialSourceLabware.id,
+          inputAddresses: selectedInputAddresses,
+          outputLabwareId: initialDestLabware.id,
+          outputAddress: address,
+        });
+      }
+      setDestinationAddress(undefined);
+    },
+    [
+      initialSourceLabware,
+      initialDestLabware,
+      destinationAddress,
+      selectedInputAddresses,
+      send,
+    ]
+  );
+
+  /**
+   * Callback to handle click on destination address for tranferring slots
+   */
+  const handleOnOutputLabwareSlotClick = React.useCallback(
+    (outputAddress: string) => {
+      setDestinationAddress(outputAddress);
+      handleCopySlots(outputAddress);
+    },
+    [handleCopySlots]
+  );
+
+  /**
+   * Handler for the "Clear" button
+   */
+  const handleOnClickClear = React.useCallback(() => {
+    if (initialDestLabware && initialDestLabware.id) {
+      send({
+        type: "CLEAR_SLOTS",
+        outputLabwareId: initialDestLabware.id,
+        outputAddresses: selectedOutputAddresses,
+      });
+      outputLabwareRef.current?.deselectAll();
+    }
+  }, [send, initialDestLabware, selectedOutputAddresses, outputLabwareRef]);
+
+  /**
+   * Whenever the SlotCopyContent map changes, or the current input labware changes,
+   * deselect any selected input slots
+   */
+  useEffect(() => {
+    inputLabwareRef.current?.deselectAll();
+  }, [slotCopyContent, initialSourceLabware]);
+
+  /**
+   * Whenever the SlotCopyContent map changes, call the onChange handler
+   */
+  useEffect(() => {
+    onChange?.(slotCopyContent, anySourceMapped);
+  }, [onChange, slotCopyContent, anySourceMapped]);
+
+  return (
+    <div className="space-y-8 mt-3 ">
+      <div className="grid grid-cols-2 auto-rows-auto">
+        <div id="sourceLabwares" className="bg-gray-100">
+          {initialSourceLabware && (
+            <Labware
+              labware={initialSourceLabware}
+              selectable="non_empty"
+              selectionMode="single"
+              labwareRef={inputLabwareRef}
+              slotColor={(address, slot) => {
+                return getSourceSlotColor(initialSourceLabware, address, slot);
+              }}
+              name={initialSourceLabware.labwareType.name}
+              onSelect={setSelectedInputAddresses}
+            />
+          )}
+        </div>
+
+        <div id="destLabwares" className="bg-gray-100">
+          {initialDestLabware && (
+            <Labware
+              labware={initialDestLabware}
+              selectable="any"
+              selectionMode="single"
+              labwareRef={outputLabwareRef}
+              name={initialDestLabware.labwareType.name}
+              onSlotClick={handleOnOutputLabwareSlotClick}
+              onSelect={setSelectedOutputAddresses}
+              slotColor={(address) =>
+                getDestinationSlotColor(initialDestLabware, address)
+              }
+            />
+          )}
+        </div>
+      </div>
+      {initialSourceLabware && initialDestLabware && (
+        <div className="border-gray-300 border-t-2 p-4 flex flex-row items-center justify-end bg-gray-200">
+          <WhiteButton onClick={handleOnClickClear}>Clear</WhiteButton>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ReagentTransferSlotMapper;

--- a/src/components/slotMapper/slotMapper.machine.ts
+++ b/src/components/slotMapper/slotMapper.machine.ts
@@ -64,6 +64,7 @@ const machineConfig: Partial<MachineOptions<
       if (e.type !== "CLEAR_SLOTS") {
         return;
       }
+      debugger;
       ctx.slotCopyContent = ctx.slotCopyContent.filter(
         (scc) => !e.outputAddresses.includes(scc.destinationAddress)
       );

--- a/src/components/slotMapper/slotMapper.machine.ts
+++ b/src/components/slotMapper/slotMapper.machine.ts
@@ -41,6 +41,9 @@ const machineConfig: Partial<MachineOptions<
         ctx.inputLabware.some((lw) => lw.barcode === scc.sourceBarcode)
       );
     }),
+    assignOutputLabware: assign((ctx, e) => {
+      e.type === "UPDATE_OUTPUT_LABWARE" && (ctx.outputLabware = e.labware);
+    }),
 
     assignLabwareColors: assign((ctx) => {
       ctx.inputLabware.forEach((lw) => {
@@ -70,7 +73,6 @@ const machineConfig: Partial<MachineOptions<
       if (e.type !== "COPY_SLOTS") {
         return;
       }
-
       const inputLabware = find(ctx.inputLabware, { id: e.inputLabwareId });
       const outputLabware = find(ctx.outputLabware, {
         id: e.outputLabwareId,
@@ -216,6 +218,9 @@ const slotMapperMachine = Machine<
               "assignLabwareColors",
               "checkSlots",
             ],
+          },
+          UPDATE_OUTPUT_LABWARE: {
+            actions: "assignOutputLabware",
           },
           LOCK: "locked",
         },

--- a/src/components/slotMapper/slotMapper.machine.ts
+++ b/src/components/slotMapper/slotMapper.machine.ts
@@ -64,7 +64,6 @@ const machineConfig: Partial<MachineOptions<
       if (e.type !== "CLEAR_SLOTS") {
         return;
       }
-      debugger;
       ctx.slotCopyContent = ctx.slotCopyContent.filter(
         (scc) => !e.outputAddresses.includes(scc.destinationAddress)
       );

--- a/src/components/slotMapper/slotMapper.types.ts
+++ b/src/components/slotMapper/slotMapper.types.ts
@@ -61,6 +61,10 @@ type UpdateInputLabwareEvent = {
   type: "UPDATE_INPUT_LABWARE";
   labware: Array<LabwareFieldsFragment>;
 };
+type UpdateOutputLabwareEvent = {
+  type: "UPDATE_OUTPUT_LABWARE";
+  labware: Array<LabwareFieldsFragment>;
+};
 
 type CopySlotsEvent = {
   type: "COPY_SLOTS";
@@ -94,6 +98,7 @@ type UnlockEvent = { type: "UNLOCK" };
 
 export type SlotMapperEvent =
   | UpdateInputLabwareEvent
+  | UpdateOutputLabwareEvent
   | CopySlotsEvent
   | ClearSlotsEvent
   | LockEvent

--- a/src/graphql/fragments/ReagentPlateFields.graphql
+++ b/src/graphql/fragments/ReagentPlateFields.graphql
@@ -1,0 +1,6 @@
+fragment ReagentPlateFields on ReagentPlate {
+    barcode
+    slots {
+        ...ReagentSlotFields
+    }
+}

--- a/src/graphql/fragments/ReagentSlotFields.graphql
+++ b/src/graphql/fragments/ReagentSlotFields.graphql
@@ -1,0 +1,4 @@
+fragment ReagentSlotFields on ReagentSlot {
+    address
+    used
+}

--- a/src/graphql/mutations/RecordReagentTransfer.graphql
+++ b/src/graphql/mutations/RecordReagentTransfer.graphql
@@ -1,0 +1,8 @@
+mutation RecordReagentTransfer($request:ReagentTransferRequest!) {
+    reagentTransfer(request:$request) {
+        operations {
+            id
+        }
+    }
+
+}

--- a/src/graphql/queries/FindReagentPlate.graphql
+++ b/src/graphql/queries/FindReagentPlate.graphql
@@ -1,0 +1,8 @@
+query FindReagentPlate ($barcode:String!) {
+    reagentPlate(barcode: $barcode) {
+        barcode,
+        slots {
+            ...ReagentSlotFields
+        }
+    }
+}

--- a/src/lib/factories/labwareFactory.ts
+++ b/src/lib/factories/labwareFactory.ts
@@ -1,10 +1,10 @@
-import {Factory} from "fishery";
-import {GridDirection, Labware, LabwareState} from "../../types/sdk";
-import {labwareTypes} from "./labwareTypeFactory";
-import {LabwareTypeName, NewLabwareLayout} from "../../types/stan";
-import {uniqueId} from "lodash";
-import {buildAddresses} from "../helpers";
-import {slotFactory} from "./slotFactory";
+import { Factory } from "fishery";
+import { GridDirection, Labware, LabwareState } from "../../types/sdk";
+import { labwareTypes } from "./labwareTypeFactory";
+import { LabwareTypeName, NewLabwareLayout } from "../../types/stan";
+import { uniqueId } from "lodash";
+import { buildAddresses } from "../helpers";
+import { slotFactory } from "./slotFactory";
 
 export const unregisteredLabwareFactory = Factory.define<NewLabwareLayout>(
   ({ params, associations, afterBuild, transientParams }) => {
@@ -119,6 +119,10 @@ export const fourSlotSlideFactory = unregisteredLabwareFactory.associations({
   labwareType: labwareTypes[LabwareTypeName.FOUR_SLOT_SLIDE].build(),
 });
 
+export const dualIndexPlateFactory = unregisteredLabwareFactory.associations({
+  labwareType: labwareTypes[LabwareTypeName.DUAL_INDEX_PLATE].build(),
+});
+
 export const labwareFactories: Record<
   LabwareTypeName,
   Factory<NewLabwareLayout>
@@ -132,4 +136,5 @@ export const labwareFactories: Record<
   [LabwareTypeName.CASSETTE]: cassetteFactory,
   [LabwareTypeName.VISIUM_ADH]: visiumADHFactory,
   [LabwareTypeName.FOUR_SLOT_SLIDE]: fourSlotSlideFactory,
+  [LabwareTypeName.DUAL_INDEX_PLATE]: dualIndexPlateFactory,
 };

--- a/src/lib/factories/labwareTypeFactory.ts
+++ b/src/lib/factories/labwareTypeFactory.ts
@@ -1,7 +1,7 @@
-import {Factory} from "fishery";
-import {LabwareType} from "../../types/sdk";
+import { Factory } from "fishery";
+import { LabwareType } from "../../types/sdk";
 import labelTypeFactory from "./labelTypeFactory";
-import {LabwareTypeName} from "../../types/stan";
+import { LabwareTypeName } from "../../types/stan";
 
 const labwareTypeFactory = Factory.define<LabwareType>(({ sequence }) => ({
   __typename: "LabwareType",
@@ -67,6 +67,12 @@ export const labwareTypes: Record<LabwareTypeName, Factory<LabwareType>> = {
     name: LabwareTypeName.FOUR_SLOT_SLIDE,
     numRows: 4,
     numColumns: 1,
+  }),
+  [LabwareTypeName.DUAL_INDEX_PLATE]: labwareTypeFactory.params({
+    __typename: "LabwareType",
+    name: LabwareTypeName.DUAL_INDEX_PLATE,
+    numRows: 8,
+    numColumns: 12,
   }),
 };
 

--- a/src/lib/machines/reagentTransfer/reagentTransferMachine.ts
+++ b/src/lib/machines/reagentTransfer/reagentTransferMachine.ts
@@ -1,0 +1,246 @@
+import { createMachine } from "xstate";
+import { assign } from "@xstate/immer";
+import { castDraft } from "immer";
+
+import { ClientError } from "graphql-request";
+import {
+  LabwareFieldsFragment,
+  Maybe,
+  ReagentPlate,
+  ReagentTransfer,
+  RecordReagentTransferMutation,
+} from "../../../types/sdk";
+import {
+  MachineServiceDone,
+  MachineServiceError,
+  OperationTypeName,
+} from "../../../types/stan";
+import { stanCore } from "../../sdk";
+
+/**
+ * Context for SlotCopy Machine
+ */
+export interface ReagentTransferContext {
+  /**
+   * The work number associated with this operation
+   */
+  workNumber: string;
+  /**
+   * The operattion type associated with this reagent transfer
+   */
+  operationType: OperationTypeName;
+
+  /**Source barcode**/
+  sourceBarcode?: string;
+
+  /**
+   * Dual Index plate, which is the source labware, from which the reagent is copied.
+   * This is fetched and if diesn't exist, will be ceated
+   */
+  sourceReagentPlate: ReagentPlate | undefined;
+
+  /**
+   * 96 well plate, which is the destination labware, to which the reagent is copied
+   */
+  destLabware: LabwareFieldsFragment | undefined;
+  /**
+   * All the transfers to record between slots in source and destination
+   */
+  reagentTransfers: Array<ReagentTransfer>;
+
+  /**The result returned by aliquot api*/
+  reagentTransferResult?: RecordReagentTransferMutation;
+  /**
+   * Errors from server, if any
+   */
+  serverErrors?: Maybe<ClientError>;
+}
+
+type UpdateTransferContent = {
+  type: "UPDATE_TRANSFER_CONTENT";
+  reagentTransfers: Array<ReagentTransfer>;
+};
+
+type UpdateWorkNumber = {
+  type: "UPDATE_WORK_NUMBER";
+  workNumber: string;
+};
+
+type SetSourceLabware = {
+  type: "SET_SOURCE_LABWARE";
+  barcode: string;
+};
+
+type SetDestinationLabware = {
+  type: "SET_DESTINATION_LABWARE";
+  labware: LabwareFieldsFragment;
+};
+
+type SaveEvent = { type: "SAVE" };
+
+export type ReagentTransferEvent =
+  | UpdateWorkNumber
+  | SetSourceLabware
+  | SetDestinationLabware
+  | UpdateTransferContent
+  | SaveEvent
+  | MachineServiceDone<"reagentTransfer", RecordReagentTransferMutation>
+  | MachineServiceError<"reagentTransfer">
+  | MachineServiceDone<"findReagentPlate", ReagentPlate>
+  | MachineServiceError<"findReagentPlate">;
+
+/**
+ * Reagent Transfer Machine Config
+ */
+export const reagentTransferMachine = createMachine<
+  ReagentTransferContext,
+  ReagentTransferEvent
+>(
+  {
+    id: "slotCopy",
+    initial: "ready",
+    states: {
+      ready: {
+        on: {
+          UPDATE_WORK_NUMBER: {
+            actions: "assignWorkNumber",
+          },
+          SET_SOURCE_LABWARE: {
+            target: "finding",
+            actions: "assignSourceBarcode",
+          },
+          SET_DESTINATION_LABWARE: {
+            actions: "assignDestination",
+          },
+          UPDATE_TRANSFER_CONTENT: [
+            {
+              target: "readyToCopy",
+              cond: (ctx) =>
+                ctx.sourceReagentPlate !== undefined &&
+                ctx.destLabware !== undefined,
+              actions: "assignTransfers",
+            },
+            {
+              actions: "assignTransfers",
+            },
+          ],
+        },
+      },
+      finding: {
+        invoke: {
+          src: "findReagentPlate",
+          onDone: {
+            target: "ready",
+            actions: "assignReagentPlate",
+          },
+          onError: {
+            target: "ready",
+            actions: ["assignServerError"],
+          },
+        },
+      },
+      readyToCopy: {
+        on: {
+          UPDATE_WORK_NUMBER: {
+            actions: "assignWorkNumber",
+          },
+          UPDATE_TRANSFER_CONTENT: {
+            actions: ["assignTransfers"],
+          },
+          SAVE: "transferring",
+        },
+      },
+      transferring: {
+        entry: ["emptyServerError"],
+        invoke: {
+          src: "reagentTransfer",
+          onDone: {
+            target: "transferred",
+            actions: "assignResult",
+          },
+          onError: {
+            target: "readyToCopy",
+            actions: ["assignServerError"],
+          },
+        },
+      },
+      transferred: {
+        type: "final",
+      },
+    },
+  },
+  {
+    actions: {
+      assignWorkNumber: assign((ctx, e) => {
+        if (e.type !== "UPDATE_WORK_NUMBER") return;
+        ctx.workNumber = e.workNumber;
+      }),
+      assignSourceBarcode: assign((ctx, e) => {
+        if (e.type !== "SET_SOURCE_LABWARE") return;
+        ctx.sourceBarcode = e.barcode;
+      }),
+      assignDestination: assign((ctx, e) => {
+        if (e.type !== "SET_DESTINATION_LABWARE") return;
+        ctx.destLabware = e.labware;
+      }),
+
+      assignReagentPlate: assign((ctx, e) => {
+        if (
+          e.type !== "done.invoke.findReagentPlate" ||
+          ctx.sourceBarcode === undefined
+        )
+          return;
+
+        let reagentPlate: ReagentPlate = {
+          barcode: ctx.sourceBarcode,
+          slots: [],
+        };
+        ctx.sourceReagentPlate = e.data ?? reagentPlate;
+        ctx.sourceReagentPlate.barcode = ctx.sourceBarcode;
+      }),
+      assignTransfers: assign((ctx, e) => {
+        e.type === "UPDATE_TRANSFER_CONTENT" &&
+          (ctx.reagentTransfers = e.reagentTransfers);
+      }),
+
+      assignResult: assign((ctx, e) => {
+        if (e.type !== "done.invoke.reagentTransfer") {
+          return;
+        }
+        ctx.reagentTransferResult = e.data;
+      }),
+
+      assignServerError: assign((ctx, e) => {
+        if (e.type !== "error.platform.reagentTransfer") {
+          return;
+        }
+        ctx.serverErrors = castDraft(e.data);
+      }),
+
+      emptyServerError: assign((ctx) => {
+        ctx.serverErrors = null;
+      }),
+    },
+    services: {
+      reagentTransfer: (ctx) => {
+        if (!ctx.sourceReagentPlate) {
+          return Promise.reject();
+        }
+        return stanCore.RecordReagentTransfer({
+          request: {
+            workNumber: ctx.workNumber,
+            operationType: ctx.operationType,
+            destinationBarcode: ctx.sourceReagentPlate.barcode,
+            transfers: ctx.reagentTransfers,
+          },
+        });
+      },
+      findReagentPlate: (ctx, e) => {
+        if (e.type !== "SET_SOURCE_LABWARE") return Promise.reject();
+        return stanCore.FindReagentPlate({ barcode: e.barcode });
+      },
+    },
+  }
+);
+
+export default reagentTransferMachine;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -38,6 +38,7 @@ import passFailHandlers from "./handlers/passFailsHandlers";
 import visiumQCHandlers from "./handlers/visiumQCHandlers";
 import visiumHandlers from "./handlers/visiumHandlers";
 import aliquotHandlers from "./handlers/aliquotHandlers";
+import reagentTransferHandlers from "./handlers/reagentTransferHandlers";
 
 export const handlers = [
   ...labwareHandlers,
@@ -77,4 +78,5 @@ export const handlers = [
   ...visiumQCHandlers,
   ...visiumHandlers,
   ...aliquotHandlers,
+  ...reagentTransferHandlers,
 ];

--- a/src/mocks/handlers/reagentTransferHandlers.ts
+++ b/src/mocks/handlers/reagentTransferHandlers.ts
@@ -1,0 +1,39 @@
+import { graphql } from "msw";
+import {
+  FindLabwareQueryVariables,
+  FindReagentPlateQuery,
+  RecordReagentTransferMutation,
+  RecordReagentTransferMutationVariables,
+} from "../../types/sdk";
+
+const reagentTransferHandlers = [
+  graphql.mutation<
+    RecordReagentTransferMutation,
+    RecordReagentTransferMutationVariables
+  >("RecordReagentTransfer", (req, res, ctx) => {
+    return res(
+      ctx.data({
+        reagentTransfer: {
+          operations: [
+            {
+              id: 1,
+            },
+          ],
+        },
+      })
+    );
+  }),
+
+  graphql.query<FindReagentPlateQuery, FindLabwareQueryVariables>(
+    "FindReagentPlate",
+    (req, res, ctx) => {
+      return res(
+        ctx.data({
+          reagentPlate: undefined,
+        })
+      );
+    }
+  ),
+];
+
+export default reagentTransferHandlers;

--- a/src/pages/DualIndexPlate.tsx
+++ b/src/pages/DualIndexPlate.tsx
@@ -27,11 +27,12 @@ import Table, {
   TableHead,
   TableHeader,
 } from "../components/Table";
+import { ErrorMessage } from "../components/forms";
 
 /**
  * Success notification when slots have been copied
  */
-const ToastSuccess = () => <Success message={"Slots copied"} />;
+const ToastSuccess = () => <Success message={"Reagents transferred"} />;
 
 function DualIndexPlate() {
   const [current, send] = useMachine(() =>
@@ -45,6 +46,15 @@ function DualIndexPlate() {
     })
   );
 
+  const {
+    serverErrors,
+    sourceReagentPlate,
+    destLabware,
+    reagentTransfers,
+    workNumber,
+    validationError,
+  } = current.context;
+
   const handleWorkNumberChange = useCallback(
     (workNumber?: string) => {
       if (workNumber) {
@@ -53,14 +63,6 @@ function DualIndexPlate() {
     },
     [send]
   );
-
-  const {
-    serverErrors,
-    sourceReagentPlate,
-    destLabware,
-    reagentTransfers,
-    workNumber,
-  } = current.context;
   /**
    * When we get into the "copied" state, show a success message
    */
@@ -144,13 +146,18 @@ function DualIndexPlate() {
           <div className="grid grid-cols-2 auto-rows-max">
             <div className="space-y-4">
               <Heading level={4}>Dual Index Plate</Heading>
-              <div className="w-1/2">
+              <div className="w-1/2" id="sourceScanInput">
                 <ScanInput
-                  onScan={(value) =>
-                    send({ type: "SET_SOURCE_LABWARE", barcode: value })
-                  }
+                  onScan={(value) => {
+                    send({ type: "SET_SOURCE_LABWARE", barcode: value });
+                  }}
                   disabled={sourceReagentPlate !== undefined}
                 />
+                {validationError && (
+                  <div className={"mt-2"}>
+                    <ErrorMessage>{validationError}</ErrorMessage>
+                  </div>
+                )}
                 <MutedText>
                   Add source labware using the scan input above
                 </MutedText>
@@ -176,6 +183,7 @@ function DualIndexPlate() {
               </div>
             </div>
           </div>
+
           <ReagentTransferSlotMapper
             initialDestLabware={destLabware}
             initialSourceLabware={memoInputLabware}
@@ -209,22 +217,17 @@ function DualIndexPlate() {
           </Table>
         </>
       )}
-      <div className={"flex flex-col w-full"}>
-        {serverErrors && <Warning error={serverErrors} />}
-      </div>
 
       <div className="border border-t-2 border-gray-200 w-full py-4 px-4 sm:px-6 lg:px-8 bg-gray-100 flex-shrink-0">
         <div className="flex flex-row items-center justify-end space-x-2">
-          {!current.matches("transferred") && (
+          {!current.matches("transferred") ? (
             <BlueButton
               disabled={reagentTransfers.length <= 0 || workNumber === ""}
               onClick={() => send({ type: "SAVE" })}
             >
               Save
             </BlueButton>
-          )}
-
-          {current.matches("copied") && (
+          ) : (
             <>
               <BlueButton onClick={reload} action="tertiary">
                 Reset Form

--- a/src/pages/DualIndexPlate.tsx
+++ b/src/pages/DualIndexPlate.tsx
@@ -21,12 +21,6 @@ import { labwareTypeInstances } from "../lib/factories/labwareTypeFactory";
 import MutedText from "../components/MutedText";
 import { buildLabwareFragment } from "../lib/helpers/labwareHelper";
 
-import Table, {
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-} from "../components/Table";
 import { ErrorMessage } from "../components/forms";
 
 /**
@@ -191,32 +185,6 @@ function DualIndexPlate() {
           />
         </div>
       </AppShell.Main>
-
-      {reagentTransfers.length > 0 && (
-        <>
-          <Heading level={4}>Mapping</Heading>
-          <Table>
-            <TableHead>
-              <tr>
-                <TableHeader>Source - Dual index plate</TableHeader>
-                <TableHeader>Destination - 96 well plate</TableHeader>
-              </tr>
-            </TableHead>
-            <TableBody>
-              {reagentTransfers.map((transfer) => (
-                <tr
-                  key={
-                    transfer.reagentPlateBarcode + transfer.reagentSlotAddress
-                  }
-                >
-                  <TableCell>{transfer.reagentSlotAddress}</TableCell>
-                  <TableCell>{transfer.destinationAddress}</TableCell>
-                </tr>
-              ))}
-            </TableBody>
-          </Table>
-        </>
-      )}
 
       <div className="border border-t-2 border-gray-200 w-full py-4 px-4 sm:px-6 lg:px-8 bg-gray-100 flex-shrink-0">
         <div className="flex flex-row items-center justify-end space-x-2">

--- a/src/pages/DualIndexPlate.tsx
+++ b/src/pages/DualIndexPlate.tsx
@@ -1,0 +1,243 @@
+import React, { useCallback, useEffect } from "react";
+import AppShell from "../components/AppShell";
+import BlueButton from "../components/buttons/BlueButton";
+import { LabwareTypeName } from "../types/stan";
+import Warning from "../components/notifications/Warning";
+import Success from "../components/notifications/Success";
+import { toast } from "react-toastify";
+import { useScrollToRef } from "../lib/hooks";
+import { useMachine } from "@xstate/react";
+import { SlotCopyContent } from "../types/sdk";
+import { Link } from "react-router-dom";
+import { reload } from "../lib/sdk";
+import WorkNumberSelect from "../components/WorkNumberSelect";
+import Heading from "../components/Heading";
+import reagentTransferMachine from "../lib/machines/reagentTransfer/reagentTransferMachine";
+import ScanInput from "../components/scanInput/ScanInput";
+import LabwareScanner from "../components/labwareScanner/LabwareScanner";
+import ReagentTransferSlotMapper from "../components/slotMapper/ReagentTransferSlotMapper";
+import labwareFactory from "../lib/factories/labwareFactory";
+import { labwareTypeInstances } from "../lib/factories/labwareTypeFactory";
+import MutedText from "../components/MutedText";
+import { buildLabwareFragment } from "../lib/helpers/labwareHelper";
+
+import Table, {
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+} from "../components/Table";
+
+/**
+ * Success notification when slots have been copied
+ */
+const ToastSuccess = () => <Success message={"Slots copied"} />;
+
+function DualIndexPlate() {
+  const [current, send] = useMachine(() =>
+    reagentTransferMachine.withContext({
+      operationType: "Dual index plate",
+      sourceReagentPlate: undefined,
+      destLabware: undefined,
+      workNumber: "",
+      reagentTransfers: [],
+      reagentTransferResult: undefined,
+    })
+  );
+
+  const handleWorkNumberChange = useCallback(
+    (workNumber?: string) => {
+      if (workNumber) {
+        send({ type: "UPDATE_WORK_NUMBER", workNumber });
+      }
+    },
+    [send]
+  );
+
+  const {
+    serverErrors,
+    sourceReagentPlate,
+    destLabware,
+    reagentTransfers,
+    workNumber,
+  } = current.context;
+  /**
+   * When we get into the "copied" state, show a success message
+   */
+  useEffect(() => {
+    if (current.value === "transferred") {
+      toast(ToastSuccess, {
+        position: toast.POSITION.TOP_RIGHT,
+        autoClose: 4000,
+        hideProgressBar: true,
+      });
+    }
+  }, [current.value]);
+
+  const memoInputLabware = React.useMemo(() => {
+    if (!sourceReagentPlate) {
+      return undefined;
+    }
+    const plate = labwareFactory.build({
+      labwareType: labwareTypeInstances.find(
+        (lt) => lt.name === LabwareTypeName.DUAL_INDEX_PLATE
+      ),
+      barcode: sourceReagentPlate.barcode,
+    });
+    plate.barcode = sourceReagentPlate.barcode;
+    if (sourceReagentPlate.slots) {
+      sourceReagentPlate.slots.forEach((slot, indx) => {
+        if (slot.used) {
+          plate.slots[indx].samples = [];
+        }
+      });
+    }
+    return buildLabwareFragment(plate);
+  }, [sourceReagentPlate]);
+
+  const handleOnSlotMapperChange = useCallback(
+    (slotCopyContent: Array<SlotCopyContent>) => {
+      const reagentTransfers = slotCopyContent.map((scc) => {
+        return {
+          reagentPlateBarcode: memoInputLabware!.barcode,
+          reagentSlotAddress: scc.sourceAddress,
+          destinationAddress: scc.destinationAddress,
+        };
+      });
+      send({ type: "UPDATE_TRANSFER_CONTENT", reagentTransfers });
+    },
+    [send, memoInputLabware]
+  );
+
+  /**
+   * When there's an error returned from the server, scroll to it
+   */
+  const [ref, scrollToRef] = useScrollToRef();
+  useEffect(() => {
+    if (serverErrors != null) {
+      scrollToRef();
+    }
+  }, [serverErrors, scrollToRef]);
+
+  return (
+    <AppShell>
+      <AppShell.Header>
+        <AppShell.Title>Dual Index Plate</AppShell.Title>
+      </AppShell.Header>
+      <AppShell.Main>
+        <div className="mx-auto">
+          {serverErrors && (
+            <div ref={ref} className="mb-4">
+              <Warning error={serverErrors} />
+            </div>
+          )}
+
+          <div className="mb-8">
+            <Heading level={3}>SGP Number</Heading>
+            <p className="mt-2">
+              Please select an SGP number to associate with this operation.
+            </p>
+            <div className="my-4 md:w-1/2">
+              <WorkNumberSelect onWorkNumberChange={handleWorkNumberChange} />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 auto-rows-max">
+            <div className="space-y-4">
+              <Heading level={4}>Dual Index Plate</Heading>
+              <div className="w-1/2">
+                <ScanInput
+                  onScan={(value) =>
+                    send({ type: "SET_SOURCE_LABWARE", barcode: value })
+                  }
+                  disabled={sourceReagentPlate !== undefined}
+                />
+                <MutedText>
+                  Add source labware using the scan input above
+                </MutedText>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <Heading level={4}>96 Well Plate</Heading>
+              <div>
+                <LabwareScanner
+                  onChange={(labwares) =>
+                    send({
+                      type: "SET_DESTINATION_LABWARE",
+                      labware: labwares[0],
+                    })
+                  }
+                  locked={destLabware !== undefined}
+                >
+                  {}
+                </LabwareScanner>
+                <MutedText>
+                  Add destination labware using the scan input above
+                </MutedText>
+              </div>
+            </div>
+          </div>
+          <ReagentTransferSlotMapper
+            initialDestLabware={destLabware}
+            initialSourceLabware={memoInputLabware}
+            onChange={handleOnSlotMapperChange}
+          />
+        </div>
+      </AppShell.Main>
+
+      {reagentTransfers.length > 0 && (
+        <>
+          <Heading level={4}>Mapping</Heading>
+          <Table>
+            <TableHead>
+              <tr>
+                <TableHeader>Source - Dual index plate</TableHeader>
+                <TableHeader>Destination - 96 well plate</TableHeader>
+              </tr>
+            </TableHead>
+            <TableBody>
+              {reagentTransfers.map((transfer) => (
+                <tr
+                  key={
+                    transfer.reagentPlateBarcode + transfer.reagentSlotAddress
+                  }
+                >
+                  <TableCell>{transfer.reagentSlotAddress}</TableCell>
+                  <TableCell>{transfer.destinationAddress}</TableCell>
+                </tr>
+              ))}
+            </TableBody>
+          </Table>
+        </>
+      )}
+      <div className={"flex flex-col w-full"}>
+        {serverErrors && <Warning error={serverErrors} />}
+      </div>
+
+      <div className="border border-t-2 border-gray-200 w-full py-4 px-4 sm:px-6 lg:px-8 bg-gray-100 flex-shrink-0">
+        <div className="flex flex-row items-center justify-end space-x-2">
+          {!current.matches("transferred") && (
+            <BlueButton
+              disabled={reagentTransfers.length <= 0 || workNumber === ""}
+              onClick={() => send({ type: "SAVE" })}
+            >
+              Save
+            </BlueButton>
+          )}
+
+          {current.matches("copied") && (
+            <>
+              <BlueButton onClick={reload} action="tertiary">
+                Reset Form
+              </BlueButton>
+              <Link to={"/"}>
+                <BlueButton action="primary">Return Home</BlueButton>
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+export default DualIndexPlate;

--- a/src/pages/DualIndexPlate.tsx
+++ b/src/pages/DualIndexPlate.tsx
@@ -182,6 +182,7 @@ function DualIndexPlate() {
             initialDestLabware={destLabware}
             initialSourceLabware={memoInputLabware}
             onChange={handleOnSlotMapperChange}
+            disabled={current.matches("transferred")}
           />
         </div>
       </AppShell.Main>

--- a/src/pages/StainingQC.tsx
+++ b/src/pages/StainingQC.tsx
@@ -154,7 +154,7 @@ export default function StainingQC({ info }: StainingQCProps) {
                 })
               }
             >
-              inputLabwares
+              Save
             </BlueButton>
           </div>
         </div>

--- a/src/pages/StainingQC.tsx
+++ b/src/pages/StainingQC.tsx
@@ -154,7 +154,7 @@ export default function StainingQC({ info }: StainingQCProps) {
                 })
               }
             >
-              Save
+              inputLabwares
             </BlueButton>
           </div>
         </div>

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -646,6 +646,7 @@ export type Mutation = {
   addFixative: Fixative;
   /** Enable or disable a fixative. */
   setFixativeEnabled: Fixative;
+  /** Create a new work type. */
   addWorkType: WorkType;
   /** Enable or disable a work type. */
   setWorkTypeEnabled: WorkType;
@@ -683,6 +684,8 @@ export type Mutation = {
   recordComplexStain: OperationResult;
   /** Transfer samples from one labware into multiple labware. */
   aliquot: OperationResult;
+  /** Record an operation transferring reagents from a reagent plate to an item of Stan labware. */
+  reagentTransfer: OperationResult;
   /** Create a new user for the application. */
   addUser: User;
   /** Set the user role (privileges) for a user. */
@@ -1179,6 +1182,15 @@ export type MutationAliquotArgs = {
  * Send information to the application.
  * These typically require a user with the suitable permission for the particular request.
  */
+export type MutationReagentTransferArgs = {
+  request: ReagentTransferRequest;
+};
+
+
+/**
+ * Send information to the application.
+ * These typically require a user with the suitable permission for the particular request.
+ */
 export type MutationAddUserArgs = {
   username: Scalars['String'];
 };
@@ -1481,6 +1493,8 @@ export type Query = {
    * work types, statuses.
    */
   workProgress: Array<WorkProgress>;
+  /** Gets a reagent plate, if it exists. May return null. */
+  reagentPlate?: Maybe<ReagentPlate>;
   /** Get the specified storage location. */
   location: Location;
   /** Get the information about stored items with the given barcodes. */
@@ -1751,6 +1765,15 @@ export type QueryWorkProgressArgs = {
  * Get information from the application.
  * These typically require no user privilege.
  */
+export type QueryReagentPlateArgs = {
+  barcode: Scalars['String'];
+};
+
+
+/**
+ * Get information from the application.
+ * These typically require no user privilege.
+ */
 export type QueryLocationArgs = {
   locationBarcode: Scalars['String'];
 };
@@ -1791,6 +1814,42 @@ export type RnaAnalysisRequest = {
   operationType: Scalars['String'];
   /** The details of what to record on one or more labware. */
   labware: Array<RnaAnalysisLabware>;
+};
+
+/** A plate of reagents. */
+export type ReagentPlate = {
+  __typename?: 'ReagentPlate';
+  barcode: Scalars['String'];
+  slots: Array<ReagentSlot>;
+};
+
+/** A slot in a reagent plate. */
+export type ReagentSlot = {
+  __typename?: 'ReagentSlot';
+  address: Scalars['Address'];
+  used: Scalars['Boolean'];
+};
+
+/** A specification that a particular reagent slot should be transferred to an address. */
+export type ReagentTransfer = {
+  /** The barcode of a reagent plate. */
+  reagentPlateBarcode: Scalars['String'];
+  /** The address of a slot in the reagent plate. */
+  reagentSlotAddress: Scalars['Address'];
+  /** The address if a slot in the destination labware. */
+  destinationAddress: Scalars['Address'];
+};
+
+/** A request to transfer reagents from reagent plates to a STAN labware. */
+export type ReagentTransferRequest = {
+  /** The name of the operation being performed. */
+  operationType: Scalars['String'];
+  /** The work number to associate with the operation. */
+  workNumber?: Maybe<Scalars['String']>;
+  /** The barcode of the destination labware. */
+  destinationBarcode: Scalars['String'];
+  /** The transfers from aliquot slots to destination slots. */
+  transfers: Array<ReagentTransfer>;
 };
 
 /** A request to record permeabilisation data. */
@@ -2423,6 +2482,20 @@ export type ProjectFieldsFragment = (
   & Pick<Project, 'name' | 'enabled'>
 );
 
+export type ReagentPlateFieldsFragment = (
+  { __typename?: 'ReagentPlate' }
+  & Pick<ReagentPlate, 'barcode'>
+  & { slots: Array<(
+    { __typename?: 'ReagentSlot' }
+    & ReagentSlotFieldsFragment
+  )> }
+);
+
+export type ReagentSlotFieldsFragment = (
+  { __typename?: 'ReagentSlot' }
+  & Pick<ReagentSlot, 'address' | 'used'>
+);
+
 export type ReleaseDestinationFieldsFragment = (
   { __typename?: 'ReleaseDestination' }
   & Pick<ReleaseDestination, 'name' | 'enabled'>
@@ -2992,6 +3065,22 @@ export type RecordPermMutationVariables = Exact<{
 export type RecordPermMutation = (
   { __typename?: 'Mutation' }
   & { recordPerm: (
+    { __typename?: 'OperationResult' }
+    & { operations: Array<(
+      { __typename?: 'Operation' }
+      & Pick<Operation, 'id'>
+    )> }
+  ) }
+);
+
+export type RecordReagentTransferMutationVariables = Exact<{
+  request: ReagentTransferRequest;
+}>;
+
+
+export type RecordReagentTransferMutation = (
+  { __typename?: 'Mutation' }
+  & { reagentTransfer: (
     { __typename?: 'OperationResult' }
     & { operations: Array<(
       { __typename?: 'Operation' }
@@ -3709,6 +3798,23 @@ export type FindPlanDataQuery = (
   ) }
 );
 
+export type FindReagentPlateQueryVariables = Exact<{
+  barcode: Scalars['String'];
+}>;
+
+
+export type FindReagentPlateQuery = (
+  { __typename?: 'Query' }
+  & { reagentPlate?: Maybe<(
+    { __typename?: 'ReagentPlate' }
+    & Pick<ReagentPlate, 'barcode'>
+    & { slots: Array<(
+      { __typename?: 'ReagentSlot' }
+      & ReagentSlotFieldsFragment
+    )> }
+  )> }
+);
+
 export type FindWorkNumbersQueryVariables = Exact<{
   status: WorkStatus;
 }>;
@@ -4244,6 +4350,20 @@ export const PrinterFieldsFragmentDoc = gql`
   }
 }
     `;
+export const ReagentSlotFieldsFragmentDoc = gql`
+    fragment ReagentSlotFields on ReagentSlot {
+  address
+  used
+}
+    `;
+export const ReagentPlateFieldsFragmentDoc = gql`
+    fragment ReagentPlateFields on ReagentPlate {
+  barcode
+  slots {
+    ...ReagentSlotFields
+  }
+}
+    ${ReagentSlotFieldsFragmentDoc}`;
 export const ReleaseDestinationFieldsFragmentDoc = gql`
     fragment ReleaseDestinationFields on ReleaseDestination {
   name
@@ -4619,6 +4739,15 @@ export const RecordOpWithSlotMeasurementsDocument = gql`
 export const RecordPermDocument = gql`
     mutation RecordPerm($request: RecordPermRequest!) {
   recordPerm(request: $request) {
+    operations {
+      id
+    }
+  }
+}
+    `;
+export const RecordReagentTransferDocument = gql`
+    mutation RecordReagentTransfer($request: ReagentTransferRequest!) {
+  reagentTransfer(request: $request) {
     operations {
       id
     }
@@ -5062,6 +5191,16 @@ export const FindPlanDataDocument = gql`
 }
     ${LabwareFieldsFragmentDoc}
 ${PlanActionFieldsFragmentDoc}`;
+export const FindReagentPlateDocument = gql`
+    query FindReagentPlate($barcode: String!) {
+  reagentPlate(barcode: $barcode) {
+    barcode
+    slots {
+      ...ReagentSlotFields
+    }
+  }
+}
+    ${ReagentSlotFieldsFragmentDoc}`;
 export const FindWorkNumbersDocument = gql`
     query FindWorkNumbers($status: WorkStatus!) {
   works(status: [$status]) {
@@ -5374,6 +5513,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     RecordPerm(variables: RecordPermMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<RecordPermMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<RecordPermMutation>(RecordPermDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'RecordPerm');
     },
+    RecordReagentTransfer(variables: RecordReagentTransferMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<RecordReagentTransferMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<RecordReagentTransferMutation>(RecordReagentTransferDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'RecordReagentTransfer');
+    },
     RecordRNAAnalysis(variables: RecordRnaAnalysisMutationVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<RecordRnaAnalysisMutation> {
       return withWrapper((wrappedRequestHeaders) => client.request<RecordRnaAnalysisMutation>(RecordRnaAnalysisDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'RecordRNAAnalysis');
     },
@@ -5502,6 +5644,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     FindPlanData(variables: FindPlanDataQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FindPlanDataQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FindPlanDataQuery>(FindPlanDataDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'FindPlanData');
+    },
+    FindReagentPlate(variables: FindReagentPlateQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FindReagentPlateQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<FindReagentPlateQuery>(FindReagentPlateDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'FindReagentPlate');
     },
     FindWorkNumbers(variables: FindWorkNumbersQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<FindWorkNumbersQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<FindWorkNumbersQuery>(FindWorkNumbersDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'FindWorkNumbers');

--- a/src/types/stan.ts
+++ b/src/types/stan.ts
@@ -7,7 +7,7 @@ import {regexSort} from "../lib/helpers";
 /**
  * Union of STAN's {@link OperationType} names
  */
-export type OperationTypeName = "Section" | "Visium cDNA";
+export type OperationTypeName = "Section" | "Visium cDNA" | "Dual index plate";
 
 /**
  * Enum for all of STAN's {@link LabwareType} names
@@ -22,6 +22,7 @@ export enum LabwareTypeName {
   CASSETTE = "Cassette",
   VISIUM_ADH = "Visium ADH",
   FOUR_SLOT_SLIDE = "4 slot slide",
+  DUAL_INDEX_PLATE= "Dual index plate"
 }
 
 export type Address = string;


### PR DESCRIPTION
Dual index plate" feature in the Visium Menu to record the transfer of dual-index reagent to our 96 well plates containing samples

1. User must select work number
2. User scans in a dual-index plate barcode which is a 24 digit number
3. User scans in a 96 well plate
4. The filled slots of 96 well plate should be displayed in green
5. The user will transfer a number of slots from the dual index plate to 96 well plate. Each source slot can only be used once.
6. The first time the user tries to use a dual index plate, the system creates it.
7. Subsequent uses of dual index plate indicate which slots are empty (greys them out in the UI) based on previous uses, otherwise in blue.
8. Transferring to an empty slot in 96 well plate will not be allowed and a warning will be given.
9. All transferred slot information is displayed in a 'Mapping' table