### PR TITLE
"RNAscope" & "IHC" staining feature

### DIFF
--- a/cypress/integration/pages/stainingSpec.ts
+++ b/cypress/integration/pages/stainingSpec.ts
@@ -63,4 +63,56 @@ describe("Staining Page", () => {
       });
     });
   });
+
+  describe("On RNSAcope and IHC Stain type selection", () => {
+    context("when RNAscope Stain Type is selected", () => {
+      before(() => {
+        cy.findByLabelText("Stain Type").select("RNAscope");
+        cy.get("#labwareScanInput").type("STAN-3111{enter}");
+      });
+      it("displays a table to enter stain information", () => {
+        cy.findByTestId("stain-info-table").contains("STAN-3111");
+      });
+      it("shows a table with RNAScope Plex Number column enabled", () => {
+        cy.findByTestId("STAN-3111-plexRNAscope").should("be.enabled");
+      });
+      it("shows a table with IHC Plex Number column disabled", () => {
+        cy.findByTestId("STAN-3111-plexIHC").should("be.disabled");
+      });
+    });
+    context("when IHC Stain Type is selected", () => {
+      before(() => {
+        cy.findByLabelText("Stain Type").select("IHC");
+      });
+      it("shows a table with IHC Plex Number column enabled", () => {
+        cy.findByTestId("STAN-3111-plexIHC").should("be.enabled");
+      });
+      it("shows a table with RNAScope Plex Number column disabled", () => {
+        cy.findByTestId("STAN-3111-plexRNAscope").should("be.disabled");
+      });
+    });
+    context("when RNAscope & IHC Stain Type is selected", () => {
+      before(() => {
+        cy.findByLabelText("Stain Type").select("RNAscope & IHC");
+      });
+      it("shows a table with RNAScope Plex Number column enabled", () => {
+        cy.findByTestId("STAN-3111-plexRNAscope").should("be.enabled");
+      });
+      it("shows a table with IHC Plex Number column enabled", () => {
+        cy.findByTestId("STAN-3111-plexIHC").should("be.enabled");
+      });
+    });
+    context(
+      "when 'Positive' is selected for experimental panel column in 'Apply all' row",
+      () => {
+        before(() => {
+          cy.get("#labwareScanInput").type("STAN-4111{enter}");
+          cy.findByTestId("all-panel").select("Positive");
+        });
+        it("selects 'Positive' value for all experimental panel columns", () => {
+          cy.findAllByText("Positive").should("have.length", 3);
+        });
+      }
+    );
+  });
 });

--- a/src/components/WorkNumberSelect.tsx
+++ b/src/components/WorkNumberSelect.tsx
@@ -76,7 +76,12 @@ export default function WorkNumberSelect({
   );
 
   return name ? (
-    <FormikSelect label={label ?? ""} name={name} emptyOption={true}>
+    <FormikSelect
+      label={label ?? ""}
+      name={name}
+      emptyOption={true}
+      onChange={handleWorkNumberChange}
+    >
       {optionValues(works, "workNumber", "workNumber")}
     </FormikSelect>
   ) : (

--- a/src/components/forms/FormikFieldValueArray.tsx
+++ b/src/components/forms/FormikFieldValueArray.tsx
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+import { useFormikContext } from "formik";
+
+type FormikFieldValueArrayProps = {
+  /**
+   * Name of the field to keep updated
+   */
+  field: string;
+
+  /**
+   * The value for the given field
+   */
+  values: string[];
+};
+
+/**
+ * Component that will keep the named Formik field updated with the given value
+ */
+export function FormikFieldValueArray({
+  field,
+  values,
+}: FormikFieldValueArrayProps) {
+  const { setFieldValue } = useFormikContext();
+
+  useEffect(() => {
+    setFieldValue(field, values);
+  }, [field, values, setFieldValue]);
+
+  return null;
+}

--- a/src/lib/validation/registrationValidation.ts
+++ b/src/lib/validation/registrationValidation.ts
@@ -54,6 +54,7 @@ export default class RegistrationValidation {
   }
 
   get hmdmc() {
+    ("");
     return Yup.string().when("species", {
       is: "Human",
       then: Yup.string()

--- a/src/pages/Staining.tsx
+++ b/src/pages/Staining.tsx
@@ -12,7 +12,7 @@ import ComplexStainForm from "./staining/ComplexStainForm";
  * By default, any new stain types will use the "simple" form. Any that need to use the
  * complex form will need to be added to the set below.
  */
-const complexStains = new Set(["RNAscope", "IHC"]);
+const complexStains = new Set(["RNAscope", "IHC", "RNAscope & IHC"]);
 const isComplexStain = (stainName: string) => complexStains.has(stainName);
 
 type StainingProps = {
@@ -36,7 +36,18 @@ export default function Staining({ stainingInfo }: StainingProps) {
                 emptyOption
                 onChange={(e) => setStainType(e.currentTarget.value)}
               >
-                {optionValues(stainingInfo.stainTypes, "name", "name")}
+                {optionValues(
+                  [
+                    ...stainingInfo.stainTypes,
+                    {
+                      __typename: "StainType",
+                      measurementTypes: [],
+                      name: "RNAscope & IHC",
+                    },
+                  ],
+                  "name",
+                  "name"
+                )}
               </Select>
             </Label>
           </div>

--- a/src/pages/staining/ComplexStainRow.tsx
+++ b/src/pages/staining/ComplexStainRow.tsx
@@ -1,0 +1,188 @@
+import React from "react";
+import {
+  ComplexStainLabware,
+  ComplexStainRequest,
+  StainPanel,
+} from "../../types/sdk";
+import { TableCell } from "../../components/Table";
+import FormikInput from "../../components/forms/Input";
+import WorkNumberSelect from "../../components/WorkNumberSelect";
+import FormikSelect from "../../components/forms/Select";
+import { objectKeys } from "../../lib/helpers";
+
+/**Properties for the setting the values for all rows**/
+type ComplexStainValueSetterProps = {
+  /**
+   * global value to set for all rows
+   */
+  stainValuesToAll: ComplexStainLabware;
+  /**
+   * function to set values in the global setter
+   * @param field
+   * @param value
+   * @param shouldValidate
+   */
+  setValueToAllStainRows: (
+    field: string,
+    value: any,
+    shouldValidate?: boolean | undefined
+  ) => void;
+};
+
+type ComplexStainRowProps = {
+  barcode: string;
+  stainType: string;
+  plexMin: number;
+  plexMax: number;
+  stainFormValues: ComplexStainRequest;
+  setFieldValue: (
+    field: string,
+    value: any,
+    shouldValidate?: boolean | undefined
+  ) => void;
+  rowID?: number;
+  stainRowApplyAllSettings?: ComplexStainValueSetterProps;
+};
+
+const ComplexStainRow = ({
+  barcode,
+  stainType,
+  plexMin,
+  plexMax,
+  rowID,
+  stainFormValues,
+  stainRowApplyAllSettings,
+  setFieldValue,
+}: ComplexStainRowProps) => {
+  const handleChange = React.useCallback(
+    (e: React.ChangeEvent<any> | { fieldName: string; value: string }) => {
+      let fieldName = "";
+      let fieldValue = "";
+      if ("fieldName" in e) {
+        fieldName = e.fieldName;
+        fieldValue = e.value;
+      } else {
+        fieldName = e.target.name;
+        fieldValue = e.currentTarget.value;
+      }
+      //Set the field value in this row
+      setFieldValue(fieldName, fieldValue);
+      if (!stainRowApplyAllSettings) return;
+      //Globally set values for all rows
+      stainFormValues.labware.forEach((_, i) => {
+        stainRowApplyAllSettings.setValueToAllStainRows(
+          `labware.${i}.${fieldName}`,
+          fieldValue
+        );
+      });
+    },
+    [stainRowApplyAllSettings, stainFormValues, setFieldValue]
+  );
+
+  const cellClassNames = `p-4 ${
+    stainRowApplyAllSettings && "font-medium text-gray-600 font-bold"
+  }`;
+  return (
+    <tr key={barcode}>
+      <TableCell className={`text-center ${cellClassNames}`}>
+        {barcode}
+      </TableCell>
+      <TableCell className={cellClassNames}>
+        <FormikInput
+          label={""}
+          name={
+            rowID !== undefined ? `labware.${rowID}.bondBarcode` : `bondBarcode`
+          }
+          onChange={handleChange}
+        />
+      </TableCell>
+      <TableCell className={cellClassNames}>
+        <FormikInput
+          label={""}
+          name={rowID !== undefined ? `labware.${rowID}.bondRun` : `bondRun`}
+          type={"number"}
+          min={0}
+          onChange={handleChange}
+        />
+      </TableCell>
+      <TableCell className={cellClassNames}>
+        <WorkNumberSelect
+          label={""}
+          name={
+            rowID !== undefined ? `labware.${rowID}.workNumber` : `workNumber`
+          }
+          onWorkNumberChange={(workNumber) => {
+            handleChange({
+              fieldName:
+                rowID !== undefined
+                  ? `labware.${rowID}.workNumber`
+                  : `workNumber`,
+              value: workNumber ?? "",
+            });
+          }}
+        />
+      </TableCell>
+      <TableCell className={cellClassNames}>
+        <FormikSelect
+          label={""}
+          name={rowID !== undefined ? `labware.${rowID}.panel` : `panel`}
+          onChange={handleChange}
+          data-testid={
+            stainRowApplyAllSettings ? "all-panel" : `${barcode}-panel`
+          }
+        >
+          {objectKeys(StainPanel).map((stainPanel) => (
+            <option key={stainPanel} value={StainPanel[stainPanel]}>
+              {stainPanel}
+            </option>
+          ))}
+        </FormikSelect>
+      </TableCell>
+      <TableCell className={cellClassNames}>
+        <FormikInput
+          label={""}
+          data-testid={`${barcode}-plexRNAscope`}
+          name={
+            rowID !== undefined
+              ? `labware.${rowID}.plexRNAscope`
+              : `plexRNAscope`
+          }
+          type={"number"}
+          min={plexMin}
+          max={plexMax}
+          step={1}
+          disabled={stainType === "IHC"}
+          value={
+            stainType === "IHC"
+              ? ""
+              : stainRowApplyAllSettings
+              ? stainRowApplyAllSettings.stainValuesToAll.plexRNAscope
+              : stainFormValues.labware[rowID!].plexRNAscope
+          }
+          onChange={handleChange}
+        />
+      </TableCell>
+      <TableCell className={cellClassNames}>
+        <FormikInput
+          data-testid={`${barcode}-plexIHC`}
+          label={""}
+          name={rowID !== undefined ? `labware.${rowID}.plexIHC` : `plexIHC`}
+          type={"number"}
+          min={plexMin}
+          max={plexMax}
+          step={1}
+          disabled={stainType === "RNAscope"}
+          onChange={handleChange}
+          value={
+            stainType === "RNAscope"
+              ? ""
+              : stainRowApplyAllSettings
+              ? stainRowApplyAllSettings.stainValuesToAll.plexIHC
+              : stainFormValues.labware[rowID!].plexIHC
+          }
+        />
+      </TableCell>
+    </tr>
+  );
+};
+export default ComplexStainRow;

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -137,16 +137,18 @@ export type ComplexStainLabware = {
   bondRun: Scalars['Int'];
   /** An optional work number to associate with this operation. */
   workNumber?: Maybe<Scalars['String']>;
+  /** The plex for RNAscope if that is being recorded. */
+  plexRNAscope?: Maybe<Scalars['Int']>;
+  /** The plex for IHC if that is being recorded. */
+  plexIHC?: Maybe<Scalars['Int']>;
+  /** The experiment panel. */
+  panel: StainPanel;
 };
 
 /** A request for a stain including bond barcodes and such. */
 export type ComplexStainRequest = {
-  /** The name of the type of stain being recorded. */
-  stainType: Scalars['String'];
-  /** The plex number. */
-  plex: Scalars['Int'];
-  /** The stain panel. */
-  panel: StainPanel;
+  /** The names of the types of stain being recorded. */
+  stainTypes: Array<Scalars['String']>;
   /** The details of the labware being stained. */
   labware: Array<ComplexStainLabware>;
 };


### PR DESCRIPTION
- RNAScope plex number, IHC plex number  and experimental panel for each slide in table
-When selecting RNAScope Stain - IHC plex number to be greyed out/not be able to be filled in
-When selecting IHC Stain - RNAscope plex number to be greyed out/not to be able to be filled in
- UI should support recording RNAScope and IHC stain in one operation
- Bond barcode - to allow 4 to 8 characters
