### PR TITLE
Block Processing and Original sample registration changes

### DIFF
--- a/cypress/integration/pages/originalSampleRegistrationSpec.ts
+++ b/cypress/integration/pages/originalSampleRegistrationSpec.ts
@@ -18,14 +18,14 @@ describe("Registration", () => {
     shouldBehaveLikeARegistrationForm(RegistrationType.TISSUE_SAMPLE);
 
     it("does not require External Identifier", () => {
-      cy.findByLabelText("External Identifier").focus().blur();
+      cy.findByTestId("External Identifier").focus().blur();
       cy.findByText("External Identifier is a required field").should(
         "not.exist"
       );
     });
 
     it("requires External Identifier to only permit certain characters", () => {
-      cy.findByLabelText("External Identifier").type("EXT&99").blur();
+      cy.findByTestId("External Identifier").type("EXT&99").blur();
       cy.findByText(
         "External Identifier contains invalid characters. Only letters, numbers, hyphens, and underscores are permitted"
       ).should("be.visible");
@@ -232,11 +232,11 @@ function fillInForm() {
     force: true,
   });
   cy.findByLabelText("Species").select("Human");
-  cy.findByLabelText("External Identifier").type("EXT_ID_1");
+  cy.findByTestId("External Identifier").type("EXT_ID_1");
   cy.findByLabelText("HuMFre").select("HuMFre1");
   cy.findByLabelText("Tissue Type").select("Liver");
   cy.findByLabelText("Spatial Location").select("3");
-  cy.findByLabelText("Replicate Number").type("2");
+  cy.findByTestId("Replicate Number").type("2");
   cy.findByLabelText("Labware Type").select("Pot");
   cy.findByLabelText("Fixative").select("None");
   cy.findByLabelText("Solution").select("Formalin");

--- a/cypress/integration/shared/registration.ts
+++ b/cypress/integration/shared/registration.ts
@@ -120,7 +120,7 @@ export function shouldBehaveLikeARegistrationForm(
         ? "doesn't require Replicate Number"
         : "requires Replicate Number",
       () => {
-        cy.findByLabelText("Replicate Number").clear().blur();
+        cy.findByTestId("Replicate Number").clear().blur();
         cy.findByText("Replicate Number is a required field").should(
           registrationType === RegistrationType.TISSUE_SAMPLE
             ? "not.exist"
@@ -130,28 +130,28 @@ export function shouldBehaveLikeARegistrationForm(
     );
 
     it("requires Replicate Number to have number part as an an integer", () => {
-      cy.findByLabelText("Replicate Number").type("1.1").blur();
+      cy.findByTestId("Replicate Number").type("1.1").blur();
       checkReplicateWarningIsVisible();
     });
 
     it("requires Replicate Number to have number part greater than 0", () => {
-      cy.findByLabelText("Replicate Number").clear().type("-1").blur();
+      cy.findByTestId("Replicate Number").clear().type("-1").blur();
       checkReplicateWarningIsVisible();
     });
 
     it("requires Replicate Number to have number part  greater than or equal to 1", () => {
-      cy.findByLabelText("Replicate Number").type("0").blur();
+      cy.findByTestId("Replicate Number").type("0").blur();
       checkReplicateWarningIsVisible();
     });
     it("requires Replicate Number to be number or number followed by a lowercase letter", () => {
-      cy.findByLabelText("Replicate Number").type("0ab").blur();
+      cy.findByTestId("Replicate Number").type("0ab").blur();
       checkReplicateWarningIsVisible();
     });
     it("requires Replicate Number to be number or number followed by a lowercase letter", () => {
-      cy.findByLabelText("Replicate Number").type("5ab").blur();
+      cy.findByTestId("Replicate Number").type("5ab").blur();
       checkReplicateWarningIsVisible();
 
-      cy.findByLabelText("Replicate Number").clear().type("5A").blur();
+      cy.findByTestId("Replicate Number").clear().type("5A").blur();
       checkReplicateWarningIsVisible();
     });
 

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -12,12 +12,14 @@ interface FormikInputProps {
   name: string;
   type?: string;
   [key: string]: any;
+  displayTag?: string;
 }
 
 const FormikInput = ({
   label,
   name,
   type = "text",
+  displayTag,
   ...rest
 }: FormikInputProps) => {
   const inputClassNames = classNames(
@@ -28,7 +30,7 @@ const FormikInput = ({
   );
   return (
     <>
-      <Label name={label}>
+      <Label name={label} displayTag={displayTag}>
         <Field type={type} className={inputClassNames} name={name} {...rest} />
       </Label>
       <FormikErrorMessage name={name} />

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -31,7 +31,13 @@ const FormikInput = ({
   return (
     <>
       <Label name={label} displayTag={displayTag}>
-        <Field type={type} className={inputClassNames} name={name} {...rest} />
+        <Field
+          type={type}
+          data-testid={label}
+          className={inputClassNames}
+          name={name}
+          {...rest}
+        />
       </Label>
       <FormikErrorMessage name={name} />
     </>

--- a/src/components/forms/Label.tsx
+++ b/src/components/forms/Label.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import classNames from "classnames";
+import Pill from "../Pill";
 
 interface LabelProps
   extends React.DetailedHTMLProps<
@@ -7,14 +8,22 @@ interface LabelProps
     HTMLLabelElement
   > {
   name: string;
+  displayTag?: string;
 }
 
-const Label = ({ name, children, className, ...rest }: LabelProps) => {
+const Label = ({
+  name,
+  displayTag,
+  children,
+  className,
+  ...rest
+}: LabelProps) => {
   const labelClassName = classNames("block", className);
 
   return (
     <label {...rest} className={labelClassName}>
-      <span className="text-gray-800">{name}</span>
+      <span className="text-gray-800 mr-3">{name}</span>
+      {displayTag && <Pill color={"pink"}>{displayTag}</Pill>}
       {children}
     </label>
   );

--- a/src/components/originalSampleProcessing/blockProcessing/BlockProcessing.tsx
+++ b/src/components/originalSampleProcessing/blockProcessing/BlockProcessing.tsx
@@ -1,6 +1,7 @@
 import {
   GetBlockProcessingInfoQuery,
   LabwareFieldsFragment,
+  NextReplicateDataFieldsFragment,
   PerformTissueBlockMutation,
   TissueBlockRequest,
 } from "../../../types/sdk";
@@ -13,9 +14,9 @@ import labwareScanTableColumns from "../../dataTable/labwareColumns";
 import * as Yup from "yup";
 import { Form, Formik } from "formik";
 import BlockProcessingLabwarePlan from "./BlockProcessingLabwarePlan";
-import { Dictionary, groupBy } from "lodash";
+import { cloneDeep, Dictionary, groupBy } from "lodash";
 import Heading from "../../Heading";
-import Planner from "../../planning/Planner";
+import Planner, { PlanChangedProps } from "../../planning/Planner";
 import createFormMachine from "../../../lib/machines/form/formMachine";
 import { stanCore } from "../../../lib/sdk";
 import WorkNumberSelect from "../../WorkNumberSelect";
@@ -27,6 +28,8 @@ import { optionValues } from "../../forms";
 import ProcessingSuccess from "../ProcessingSuccess";
 import { useConfirmLeave } from "../../../lib/hooks";
 import { Prompt } from "react-router-dom";
+import { Row } from "react-table";
+import FormikInput from "../../forms/Input";
 
 /**
  * Used as Formik's values
@@ -37,12 +40,12 @@ export type BlockFormValue = {
   replicateNumber: string;
   medium?: string;
   commentId?: number;
-  discardSource?: boolean;
   preBarcode?: string;
 };
 export type BlockFormData = {
   workNumber: string;
   plans: BlockFormValue[];
+  discardSources?: { sourceBarcode: string; discard: boolean }[];
 };
 
 const allowedLabwareTypeNames: Array<LabwareTypeName> = [
@@ -75,6 +78,7 @@ export default function BlockProcessing({
     })
   );
 
+  const { submissionResult, serverError } = current.context;
   /**
    * For tracking whether the user gets a prompt if they tried to navigate to another page
    */
@@ -84,7 +88,17 @@ export default function BlockProcessing({
     LabwareTypeName.TUBE
   );
   const [numLabware, setNumLabware] = React.useState<number>(1);
-  const { submissionResult, serverError } = current.context;
+
+  /**Next replicate data  for all source labware scanned**/
+  const [nextReplicateData, setNextReplicateData] = React.useState<
+    NextReplicateDataFieldsFragment[]
+  >([]);
+
+  /**To keep the mapping between source selected and the plan. Key is source labware barcode and value is unique id for a plan created**/
+  const [planToSourceMap, setPlanToSourceMap] = React.useState(
+    new Map<string, string>()
+  );
+
   /**
    * Limit the labware types the user can Section on to.
    */
@@ -96,6 +110,27 @@ export default function BlockProcessing({
           )
         : [],
     [processingInfo]
+  );
+
+  /**A source is selected for a plan, so update the mapping state between source and plan**/
+  const notifySourceSelection = React.useCallback(
+    (cid: string, sourceBarcode: string) => {
+      if (
+        planToSourceMap.has(cid) &&
+        planToSourceMap.get(cid) === sourceBarcode
+      ) {
+        return;
+      }
+      setPlanToSourceMap((prev) => {
+        const map = new Map<string, string>();
+        Array.from(prev.entries()).forEach(([key, value]) => {
+          map.set(key, value);
+        });
+        map.set(cid, sourceBarcode);
+        return map;
+      });
+    },
+    [planToSourceMap]
   );
 
   /** Display created Labware plans**/
@@ -123,6 +158,7 @@ export default function BlockProcessing({
         planWithKeys,
         (planWithKey) => planWithKey.plan!.labwareType.name
       );
+      const nextReplicateDataCopy = cloneDeep(nextReplicateData);
 
       let rowIndx: number = 0;
       return Object.keys(layoutPlanGroupedByType).length > 0 ? (
@@ -141,6 +177,25 @@ export default function BlockProcessing({
                     level={2}
                   >{`${labwareType.toString()}s`}</Heading>
                   {labwarePlans.map((lwPlan, indx) => {
+                    //Auto numbering for replicateNumbers
+                    const sourcebarcode = planToSourceMap.get(lwPlan.cid);
+                    /** Make sure
+                     * 1) All labware with sources having same original samples(donor id + spatial location) are numbered consecutively
+                     * 2) All labware with same source are numbered consecutively
+                     ***/
+                    let replicateData:
+                      | NextReplicateDataFieldsFragment
+                      | undefined = undefined;
+                    if (sourcebarcode) {
+                      replicateData = nextReplicateDataCopy.find((repData) =>
+                        repData.barcodes.some(
+                          (barcode) => barcode === sourcebarcode
+                        )
+                      );
+                      if (replicateData) {
+                        replicateData.nextReplicateNumber++;
+                      }
+                    }
                     rowIndx++;
                     return (
                       <BlockProcessingLabwarePlan
@@ -152,12 +207,18 @@ export default function BlockProcessing({
                         sampleColors={sampleColors}
                         onDelete={deleteAction}
                         rowIndex={rowIndx - 1}
+                        replicateNumber={
+                          replicateData
+                            ? replicateData.nextReplicateNumber - 1
+                            : -1
+                        }
                         ref={
                           labwareType === selectedLabwareType &&
                           indx === labwarePlans.length - numLabware
                             ? scrollRef
                             : undefined
                         }
+                        notifySourceSelection={notifySourceSelection}
                       />
                     );
                   })}
@@ -170,7 +231,14 @@ export default function BlockProcessing({
         <></>
       );
     },
-    [processingInfo, selectedLabwareType, numLabware]
+    [
+      processingInfo,
+      selectedLabwareType,
+      numLabware,
+      nextReplicateData,
+      notifySourceSelection,
+      planToSourceMap,
+    ]
   );
 
   /**
@@ -212,17 +280,21 @@ export default function BlockProcessing({
    */
   function buildValidationSchema(): Yup.ObjectSchema {
     return Yup.object().shape({
-      workNumber: Yup.string().required(),
+      workNumber: Yup.string().required("SGP Number is required"),
       plans: Yup.array()
         .of(
           Yup.object().shape({
             sourceBarcode: Yup.string().required().min(1),
             medium: Yup.string()
-              .required("Medium is a required field.")
-              .oneOf(processingInfo.mediums.map((medium) => medium.name)),
-            replicateNumber: Yup.string().required(),
+              .required("Medium is required")
+              .oneOf(
+                processingInfo.mediums.map((medium) => medium.name),
+                "Medium is required"
+              ),
+            replicateNumber: Yup.string().required(
+              "Replicate number is required"
+            ),
             commentId: Yup.number().optional(),
-            discardSource: Yup.boolean().optional(),
             labwareType: Yup.string()
               .required()
               .oneOf(allowedLabwareTypes.map((type) => type.name)),
@@ -230,7 +302,7 @@ export default function BlockProcessing({
               is: (value: string) =>
                 value === LabwareTypeName.PRE_BARCODED_TUBE,
               then: Yup.string()
-                .required("Barcode is a required field.")
+                .required("Barcode is required")
                 .matches(
                   /[a-zA-Z]{2}\d{8}/,
                   "Barcode should be in the format with two letters followed by 8 numbers"
@@ -240,6 +312,14 @@ export default function BlockProcessing({
         )
         .required()
         .min(1),
+      discardSources: Yup.array()
+        .of(
+          Yup.object().shape({
+            sourceBarcode: Yup.string().optional(),
+            discard: Yup.boolean().optional(),
+          })
+        )
+        .optional(),
     });
   }
 
@@ -257,12 +337,69 @@ export default function BlockProcessing({
         medium: plan.medium ?? "",
         labwareType: plan.labwareType,
       })),
-      discardSourceBarcodes: formData.plans
-        .filter((plan) => plan.discardSource === true)
-        .map((plan) => plan.sourceBarcode),
+      discardSourceBarcodes: formData.discardSources
+        ?.filter((ds) => ds.discard)
+        .map((ds) => ds.sourceBarcode),
     };
   };
 
+  const discardSourceColumn = React.useMemo(() => {
+    return {
+      Header: "Discard Source",
+      id: "discard_source",
+      Cell: ({ row }: { row: Row<LabwareFieldsFragment> }) => {
+        return (
+          <>
+            <FormikInput
+              name={`discardSources.${row.index}.sourceBarcode`}
+              label={""}
+              type={"hidden"}
+              value={row.original.barcode}
+            />
+            <FormikInput
+              label={""}
+              className={"content-center align-middle justify-center"}
+              name={`discardSources.${row.index}.discard`}
+              type={"checkbox"}
+            />
+          </>
+        );
+      },
+    };
+  }, []);
+
+  /**Notifies about a plan change - so  make sure that we have fetched nextReplicateData for all source labware scanned
+   * This is the only place we can check it, as we don't have a specific action to denote all source labware scanning is finished
+   * Inorder to avoid unnecessary fetching of same data multiple times on each plan change, we are checking it against the stored nextReplicateData
+   * **/
+  const onPlanChanged = React.useCallback(
+    (planChangedProps: PlanChangedProps<undefined>) => {
+      if (planChangedProps.numberOfPlans === 0) {
+        return;
+      }
+      async function fetchNextReplicateData() {
+        const barcodes = planChangedProps.sourceLabware.map((lw) => lw.barcode);
+        return await stanCore.GetNextReplicateNumber({ barcodes });
+      }
+      if (nextReplicateData.length > 0) {
+        /**Any update is source labwared scanned**/
+        const barcodes = nextReplicateData.flatMap((rd) => rd.barcodes);
+        if (
+          planChangedProps.sourceLabware.length === barcodes.length &&
+          planChangedProps.sourceLabware.every((sourceLw) =>
+            barcodes.includes(sourceLw.barcode)
+          )
+        ) {
+          return;
+        }
+      }
+      /**There is update, so fetch next Replicate data for all**/
+      fetchNextReplicateData().then((res) =>
+        setNextReplicateData(res.nextReplicateNumbers)
+      );
+    },
+    [nextReplicateData]
+  );
   /**Save operation performed, so display the success page**/
   if (current.matches("submitted") && submissionResult) {
     return (
@@ -302,7 +439,7 @@ export default function BlockProcessing({
               });
             }}
           >
-            {({ setFieldValue, isValid, values }) => (
+            {({ setFieldValue, values }) => (
               <Form>
                 <motion.div
                   variants={variants.fadeInWithLift}
@@ -330,14 +467,14 @@ export default function BlockProcessing({
                       (lt) => lt.name === selectedLabwareType
                     )}
                     numPlansToCreate={numLabware}
-                    onPlanChanged={() => {}}
+                    onPlanChanged={onPlanChanged}
                     buildPlanLayouts={buildPlanLayouts}
                     columns={[
                       labwareScanTableColumns.barcode(),
+                      discardSourceColumn,
                       labwareScanTableColumns.donorId(),
                       labwareScanTableColumns.tissueType(),
                       labwareScanTableColumns.spatialLocation(),
-                      labwareScanTableColumns.replicate(),
                     ]}
                     buildPlanCreationSettings={buildPlanCreationSettings}
                   />
@@ -353,9 +490,7 @@ export default function BlockProcessing({
                       className={"sm:flex mt-4 sm:flex-row justify-end"}
                     >
                       <ButtonBar>
-                        <BlueButton disabled={!isValid} type={"submit"}>
-                          Save
-                        </BlueButton>
+                        <BlueButton type={"submit"}>Save</BlueButton>
                       </ButtonBar>
                     </motion.div>
                   )}

--- a/src/components/originalSampleProcessing/blockProcessing/BlockProcessingLabwarePlan.tsx
+++ b/src/components/originalSampleProcessing/blockProcessing/BlockProcessingLabwarePlan.tsx
@@ -58,6 +58,9 @@ type BlockProcessingLabwarePlanProps = {
    * rowIndex representing form data array index
    */
   rowIndex: number;
+
+  replicateNumber: number;
+  notifySourceSelection: (cid: string, sourceBarcode: string) => void;
 };
 
 /**
@@ -100,6 +103,8 @@ const BlockProcessingLabwarePlan = React.forwardRef<
       sampleColors,
       onDelete,
       rowIndex,
+      replicateNumber,
+      notifySourceSelection,
     },
     ref
   ) => {
@@ -116,28 +121,65 @@ const BlockProcessingLabwarePlan = React.forwardRef<
      * Fill all form fields that need to be auto-filled
      */
     React.useEffect(() => {
-      setFieldValue(`plans.${rowIndex}.replicateNumber`, rowIndex + 1 + "");
+      sourceLabware.forEach((source, indx) => {
+        setFieldValue(`discardSources.${indx}.sourceBarcode`, source.barcode);
+      });
+    }, [setFieldValue, rowIndex, sourceLabware]);
+
+    React.useEffect(() => {
       setFieldValue(
         `plans.${rowIndex}.labwareType`,
         outputLabware.labwareType.name
       );
-    }, [setFieldValue, rowIndex, outputLabware]);
+    }, [outputLabware, rowIndex, setFieldValue]);
 
+    React.useEffect(() => {
+      setFieldValue(
+        `plans.${rowIndex}.replicateNumber`,
+        replicateNumber === -1 ? "" : replicateNumber + ""
+      );
+    }, [replicateNumber, rowIndex, setFieldValue]);
+
+    React.useEffect(() => {
+      const defaultMediumForlabwareTyps = [
+        { lwType: LabwareTypeName.PRE_BARCODED_TUBE, medium: "None" },
+        { lwType: LabwareTypeName.TUBE, medium: "None" },
+        { lwType: LabwareTypeName.PROVIASETTE, medium: "OCT" },
+        { lwType: LabwareTypeName.CASSETTE, medium: "Paraffin" },
+      ];
+      const mediumLwType = defaultMediumForlabwareTyps.find(
+        (item) =>
+          item.lwType === outputLabware.labwareType.name &&
+          blockProcessInfo.mediums.find(
+            (medium) => medium.name === item.medium
+          ) !== undefined
+      );
+      mediumLwType &&
+        setFieldValue(`plans.${rowIndex}.medium`, mediumLwType.medium);
+    }, [blockProcessInfo, setFieldValue, outputLabware, rowIndex]);
     /**
      * Fill source barcode in form data
+     * and
+     * Notify parent about change in source (This is for auto numbering of replicate numbers)
      */
     React.useEffect(() => {
       if (layoutPlan.plannedActions.size <= 0) return;
-      const plannedActions:
-        | Source[]
-        | undefined = layoutPlan.plannedActions.get("A1");
+      const plannedActions: Source[] | undefined =
+        layoutPlan.plannedActions.get("A1");
       if (plannedActions && plannedActions.length > 0) {
         setFieldValue(
           `plans.${rowIndex}.sourceBarcode`,
           plannedActions[0].labware.barcode
         );
+        notifySourceSelection(cid, plannedActions[0].labware.barcode);
       }
-    }, [setFieldValue, rowIndex, layoutPlan.plannedActions]);
+    }, [
+      setFieldValue,
+      rowIndex,
+      layoutPlan.plannedActions,
+      cid,
+      notifySourceSelection,
+    ]);
     return (
       <motion.div
         variants={variants.fadeInWithLift}
@@ -211,11 +253,6 @@ const BlockProcessingLabwarePlan = React.forwardRef<
                 >
                   {optionValues(blockProcessInfo.comments, "text", "id")}
                 </FormikSelect>
-                <FormikInput
-                  label={"Discard source?"}
-                  name={`plans.${rowIndex}.discardSource`}
-                  type={"checkbox"}
-                />
               </div>
 
               {current.matches("prep") && (

--- a/src/graphql/fragments/NextReplicateDataFields.graphql
+++ b/src/graphql/fragments/NextReplicateDataFields.graphql
@@ -1,0 +1,6 @@
+fragment NextReplicateDataFields on NextReplicateData {
+    barcodes
+    donorId
+    nextReplicateNumber
+    spatialLocationId
+} 

--- a/src/graphql/queries/GetNextReplicateNumber.graphql
+++ b/src/graphql/queries/GetNextReplicateNumber.graphql
@@ -1,0 +1,5 @@
+query GetNextReplicateNumber($barcodes:[String!]!) {
+    nextReplicateNumbers(barcodes: $barcodes) {
+        ...NextReplicateDataFields
+    }
+}

--- a/src/mocks/handlers/originalSampleProcessingHandlers.ts
+++ b/src/mocks/handlers/originalSampleProcessingHandlers.ts
@@ -2,8 +2,11 @@ import { graphql } from "msw";
 import {
   GetBlockProcessingInfoQuery,
   GetBlockProcessingInfoQueryVariables,
+  GetNextReplicateNumberQuery,
+  GetNextReplicateNumberQueryVariables,
   GetPotProcessingInfoQuery,
   GetPotProcessingInfoQueryVariables,
+  NextReplicateData,
   PerformTissueBlockMutation,
   PerformTissueBlockMutationVariables,
   PerformTissuePotMutation,
@@ -53,6 +56,27 @@ const originalSampleProcessingHandlers = [
       );
     }
   ),
+  graphql.query<
+    GetNextReplicateNumberQuery,
+    GetNextReplicateNumberQueryVariables
+  >("GetNextReplicateNumber", (req, res, ctx) => {
+    const sourceBarcodes = [...req.variables.barcodes];
+    const nextReplicateData: NextReplicateData[] = [];
+    /***Keeps labware in pairs as a group. This is to enable testing for all cases**/
+    for (let indx = 0; indx < sourceBarcodes.length; indx += 2) {
+      nextReplicateData.push({
+        barcodes: sourceBarcodes.slice(indx, indx + 2),
+        nextReplicateNumber: 5,
+        donorId: 1,
+        spatialLocationId: 1,
+      });
+    }
+    return res(
+      ctx.data({
+        nextReplicateNumbers: nextReplicateData,
+      })
+    );
+  }),
   graphql.mutation<
     PerformTissueBlockMutation,
     PerformTissueBlockMutationVariables

--- a/src/pages/OriginalSampleRegistration.tsx
+++ b/src/pages/OriginalSampleRegistration.tsx
@@ -168,7 +168,8 @@ function OriginalSampleRegistration({ registrationInfo }: RegistrationParams) {
    * The changes are mapped here so that Registration and RegistrationForm components  can be reused **/
   const keywords = new Map()
     .set("Block", "Sample")
-    .set("Embedding", "Solution");
+    .set("Embedding", "Solution")
+    .set("Optional", ["Replicate Number", "External Identifier"]);
   return (
     <Registration<
       RegisterOriginalSamplesMutationVariables,

--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -20,7 +20,6 @@ import GrayBox, { Sidebar } from "../../components/layouts/GrayBox";
 import { useScrollToRef } from "../../lib/hooks";
 import { RegistrationFormValues } from "../BlockRegistration";
 import { TissueValues } from "./Registration";
-
 export type TextType = "Block" | "Embedding";
 
 interface RegistrationFormParams<T> {
@@ -49,24 +48,21 @@ const RegistrationForm = <T extends TissueValues<B>, B>({
   keywordsMap,
 }: RegistrationFormParams<T>) => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const {
-    setFieldValue,
-    values,
-    errors,
-    touched,
-    isSubmitting,
-  } = useFormikContext<RegistrationFormValues>();
+  const { setFieldValue, values, errors, touched, isSubmitting } =
+    useFormikContext<RegistrationFormValues>();
 
   const keywords = keywordsMap ?? new Map();
+  const optionalFields = keywords.has("Optional") && keywords.get("Optional");
 
   // Available spatial locations are determined by the current tissue type
-  const availableSpatialLocations: GetRegistrationInfoQuery["tissueTypes"][number]["spatialLocations"] = useMemo(() => {
-    return (
-      registrationInfo.tissueTypes.find(
-        (tt) => tt.name === values.tissues[currentIndex].tissueType
-      )?.spatialLocations ?? []
-    );
-  }, [registrationInfo.tissueTypes, values.tissues, currentIndex]);
+  const availableSpatialLocations: GetRegistrationInfoQuery["tissueTypes"][number]["spatialLocations"] =
+    useMemo(() => {
+      return (
+        registrationInfo.tissueTypes.find(
+          (tt) => tt.name === values.tissues[currentIndex].tissueType
+        )?.spatialLocations ?? []
+      );
+    }, [registrationInfo.tissueTypes, values.tissues, currentIndex]);
 
   // Only enable HMDMC when the species is Human
   const isHMDMCEnabled = values.tissues[currentIndex].species === "Human";
@@ -80,6 +76,11 @@ const RegistrationForm = <T extends TissueValues<B>, B>({
   const tissueRef = useRef<HTMLDivElement>(null);
 
   const [lastBlockRef, scrollToLatestBlock] = useScrollToRef();
+
+  const getOptionalTag = (fieldName: string) =>
+    optionalFields && optionalFields.includes(fieldName)
+      ? "Optional"
+      : undefined;
 
   return (
     <Form>
@@ -210,6 +211,7 @@ const RegistrationForm = <T extends TissueValues<B>, B>({
                         <FormikInput
                           label="External Identifier"
                           name={`tissues.${currentIndex}.blocks.${blockIndex}.externalIdentifier`}
+                          displayTag={getOptionalTag("External Identifier")}
                         />
 
                         <FormikSelect
@@ -228,6 +230,7 @@ const RegistrationForm = <T extends TissueValues<B>, B>({
                         <FormikInput
                           label="Replicate Number"
                           name={`tissues.${currentIndex}.blocks.${blockIndex}.replicateNumber`}
+                          displayTag={getOptionalTag("Replicate Number")}
                         />
                         {"lastKnownSectionNumber" in
                           values.tissues[currentIndex].blocks[blockIndex] && (

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -1318,6 +1318,19 @@ export type MutationSetLocationCustomNameArgs = {
   customName?: Maybe<Scalars['String']>;
 };
 
+/** The data about original tissues and their next replicate numbers. */
+export type NextReplicateData = {
+  __typename?: 'NextReplicateData';
+  /** The source barcodes for the new replicates. */
+  barcodes: Array<Scalars['String']>;
+  /** The id of the donor. */
+  donorId: Scalars['Int'];
+  /** The id of the spatial location. */
+  spatialLocationId: Scalars['Int'];
+  /** The next replicate number for this group. */
+  nextReplicateNumber: Scalars['Int'];
+};
+
 /** An operation and the pass/fails in the slots of its labware. */
 export type OpPassFail = {
   __typename?: 'OpPassFail';
@@ -1616,6 +1629,8 @@ export type Query = {
   workProgress: Array<WorkProgress>;
   /** Gets a reagent plate, if it exists. May return null. */
   reagentPlate?: Maybe<ReagentPlate>;
+  /** Gets the next replicate data for the given source labware barcodes. */
+  nextReplicateNumbers: Array<NextReplicateData>;
   /** Get the specified storage location. */
   location: Location;
   /** Get the information about stored items with the given barcodes. */
@@ -1897,6 +1912,15 @@ export type QueryWorkProgressArgs = {
  */
 export type QueryReagentPlateArgs = {
   barcode: Scalars['String'];
+};
+
+
+/**
+ * Get information from the application.
+ * These typically require no user privilege.
+ */
+export type QueryNextReplicateNumbersArgs = {
+  barcodes: Array<Scalars['String']>;
 };
 
 
@@ -2601,6 +2625,11 @@ export type LocationFieldsFragment = (
     { __typename?: 'LinkedLocation' }
     & Pick<LinkedLocation, 'barcode' | 'fixedName' | 'customName' | 'address'>
   )> }
+);
+
+export type NextReplicateDataFieldsFragment = (
+  { __typename?: 'NextReplicateData' }
+  & Pick<NextReplicateData, 'barcodes' | 'donorId' | 'nextReplicateNumber' | 'spatialLocationId'>
 );
 
 export type OperationFieldsFragment = (
@@ -4267,6 +4296,19 @@ export type GetLabwareInLocationQuery = (
   )> }
 );
 
+export type GetNextReplicateNumberQueryVariables = Exact<{
+  barcodes: Array<Scalars['String']> | Scalars['String'];
+}>;
+
+
+export type GetNextReplicateNumberQuery = (
+  { __typename?: 'Query' }
+  & { nextReplicateNumbers: Array<(
+    { __typename?: 'NextReplicateData' }
+    & NextReplicateDataFieldsFragment
+  )> }
+);
+
 export type GetPotProcessingInfoQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -4637,6 +4679,14 @@ export const LocationFieldsFragmentDoc = gql`
     customName
     address
   }
+}
+    `;
+export const NextReplicateDataFieldsFragmentDoc = gql`
+    fragment NextReplicateDataFields on NextReplicateData {
+  barcodes
+  donorId
+  nextReplicateNumber
+  spatialLocationId
 }
     `;
 export const ActionFieldsFragmentDoc = gql`
@@ -5761,6 +5811,13 @@ export const GetLabwareInLocationDocument = gql`
   }
 }
     ${LabwareFieldsFragmentDoc}`;
+export const GetNextReplicateNumberDocument = gql`
+    query GetNextReplicateNumber($barcodes: [String!]!) {
+  nextReplicateNumbers(barcodes: $barcodes) {
+    ...NextReplicateDataFields
+  }
+}
+    ${NextReplicateDataFieldsFragmentDoc}`;
 export const GetPotProcessingInfoDocument = gql`
     query GetPotProcessingInfo {
   fixatives {
@@ -6176,6 +6233,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetLabwareInLocation(variables: GetLabwareInLocationQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetLabwareInLocationQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetLabwareInLocationQuery>(GetLabwareInLocationDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetLabwareInLocation');
+    },
+    GetNextReplicateNumber(variables: GetNextReplicateNumberQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetNextReplicateNumberQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetNextReplicateNumberQuery>(GetNextReplicateNumberDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetNextReplicateNumber');
     },
     GetPotProcessingInfo(variables?: GetPotProcessingInfoQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<GetPotProcessingInfoQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetPotProcessingInfoQuery>(GetPotProcessingInfoDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'GetPotProcessingInfo');


### PR DESCRIPTION
Auto numbering changes for Replicate Numbers in Block Processing
- Replicate numbers for all labware with same source labware should be numbered consecutively
- Replicate numbers for all labware with source labware having same original samples should be numbered consecutively

Original sample Registration
-Display 'Optional' tag for 'Replicate Number' and 'External Identifier'
