### PR TITLE
X925 multiple pot registration

### DIFF
--- a/cypress/e2e/pages/originalSampleRegistration.cy.ts
+++ b/cypress/e2e/pages/originalSampleRegistration.cy.ts
@@ -28,6 +28,9 @@ describe('Registration', () => {
       cy.findByLabelText('Labware Type').focus().blur();
       cy.findByText('Labware Type is a required field').should('be.visible');
     });
+    it('displays add button for identical samples', () => {
+      cy.findByText('+ Add Identical Tissue Sample').should('be.visible');
+    });
   });
 
   context('when clicking the Add Another Tissue Sample button', () => {
@@ -43,6 +46,33 @@ describe('Registration', () => {
 
     it('shows the Delete Sample button for each sample', () => {
       cy.findAllByText('Delete Sample').should('be.visible');
+    });
+  });
+
+  context('when clicking the Add Identical Tissue Sample button', () => {
+    before(() => {
+      cy.visit('/admin/tissue_registration');
+      fillInForm();
+      cy.findByText('+ Add Identical Tissue Sample').focus().click();
+    });
+
+    it('adds another tissue sample', () => {
+      cy.findByText('Sample Information').siblings().should('have.length', 2);
+    });
+
+    it('shows the Delete Sample button for each sample', () => {
+      cy.findAllByText('Delete Sample').should('be.visible');
+    });
+    it('shows identical information for the created sample with Replicate Number, Fixative, Solution as empty', () => {
+      cy.findAllByTestId('Replicate Number').eq(1).should('have.value', '');
+      cy.findAllByLabelText('Fixative').eq(1).should('have.value', '');
+      cy.findAllByLabelText('Solution').eq(1).should('have.value', '');
+      cy.findAllByLabelText('Spatial Location')
+        .eq(1)
+        .find('option:selected')
+        .should('have.text', '3 - Surface central region');
+      cy.findAllByTestId('External Identifier').eq(1).should('have.value', 'EXT_ID_1');
+      cy.findAllByLabelText('Labware Type').eq(1).find('option:selected').should('have.text', 'Pot');
     });
   });
 

--- a/cypress/e2e/pages/originalSampleRegistration.cy.ts
+++ b/cypress/e2e/pages/originalSampleRegistration.cy.ts
@@ -75,16 +75,38 @@ describe('Registration', () => {
       cy.findAllByLabelText('Labware Type').eq(1).find('option:selected').should('have.text', 'Pot');
     });
   });
-
-  context('when clicking the Add Another Tissue button', () => {
+  context('when clicking the Add Identical Tissue button', () => {
     before(() => {
-      cy.findByText('- Delete Tissue').should('not.exist');
       cy.get('#tissue-summaries').children().should('have.length', 1);
-      cy.findByText('+ Add Another Tissue').click();
+      cy.findByText('- Remove Tissue').should('not.exist');
+      cy.findByText('+ Add Identical Tissue').click();
     });
 
     it('adds another tissue', () => {
       cy.get('#tissue-summaries').children().should('have.length', 2);
+      cy.findByText('- Remove Tissue').should('exist');
+    });
+    it('shows identical information for the created sample with Replicate Number, Fixative, Solution as empty', () => {
+      cy.findAllByTestId('Replicate Number').eq(1).should('have.value', '');
+      cy.findAllByLabelText('Fixative').eq(1).should('have.value', '');
+      cy.findAllByLabelText('Solution').eq(1).should('have.value', '');
+      cy.findAllByTestId('External Identifier').eq(1).should('have.value', '');
+      cy.findAllByLabelText('Spatial Location')
+        .eq(1)
+        .find('option:selected')
+        .should('have.text', '3 - Surface central region');
+      cy.findAllByLabelText('Labware Type').eq(1).find('option:selected').should('have.text', 'Pot');
+    });
+  });
+
+  context('when clicking the Add Another Tissue button', () => {
+    before(() => {
+      cy.get('#tissue-summaries').children().should('have.length', 2);
+      cy.findByText('+ Add Another Tissue').click();
+    });
+
+    it('adds another tissue', () => {
+      cy.get('#tissue-summaries').children().should('have.length', 3);
     });
   });
 

--- a/cypress/e2e/pages/originalSampleRegistration.cy.ts
+++ b/cypress/e2e/pages/originalSampleRegistration.cy.ts
@@ -67,11 +67,11 @@ describe('Registration', () => {
       cy.findAllByTestId('Replicate Number').eq(1).should('have.value', '');
       cy.findAllByLabelText('Fixative').eq(1).should('have.value', '');
       cy.findAllByLabelText('Solution').eq(1).should('have.value', '');
+      cy.findAllByTestId('External Identifier').eq(1).should('have.value', '');
       cy.findAllByLabelText('Spatial Location')
         .eq(1)
         .find('option:selected')
         .should('have.text', '3 - Surface central region');
-      cy.findAllByTestId('External Identifier').eq(1).should('have.value', 'EXT_ID_1');
       cy.findAllByLabelText('Labware Type').eq(1).find('option:selected').should('have.text', 'Pot');
     });
   });

--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -236,21 +236,57 @@ const RegistrationForm = <T extends TissueValues<B>, B>({
                             {optionValues(registrationInfo.solutions, 'name', 'name')}
                           </FormikSelect>
                         )}
+                        <div className={'flex flex-row justify-end'}>
+                          {'solution' in block && (
+                            <FieldArray name={`tissues.${currentIndex}.blocks`}>
+                              {(blockHelpers) => (
+                                <BlueButton
+                                  type="button"
+                                  action="secondary"
+                                  className="mt-4 inline-flex"
+                                  onClick={() => {
+                                    //Create new sample fields refilled with the sample from which this is invoked. Reset Solution,Fixative and Replicate Number fields
+                                    blockHelpers.push(block);
+                                    setFieldValue(
+                                      `tissues[${currentIndex}].blocks[${values.tissues[currentIndex].blocks.length}].solution`,
+                                      ''
+                                    );
+                                    setFieldValue(
+                                      `tissues[${currentIndex}].blocks[${values.tissues[currentIndex].blocks.length}].fixative`,
+                                      ''
+                                    );
+                                    setFieldValue(
+                                      `tissues[${currentIndex}].blocks[${values.tissues[currentIndex].blocks.length}].replicateNumber`,
+                                      ''
+                                    );
+                                    scrollToLatestBlock();
+                                  }}
+                                >
+                                  {`+ Add Identical Tissue ${keywords.get('Block') ?? 'Block'}`}
+                                </BlueButton>
+                              )}
+                            </FieldArray>
+                          )}
 
-                        {/* Only show the delete button if we've got more than 1 block */}
-                        {values.tissues[currentIndex].blocks.length > 1 && (
-                          <div className="flex justify-end">
-                            <PinkButton
-                              type="button"
-                              action="tertiary"
-                              onClick={() => {
-                                setFieldValue(`tissues[${currentIndex}].blocks[${blockIndex}].clientId`, null);
-                              }}
-                            >
-                              {`Delete ${keywords.get('Block') ?? 'Block'}`}
-                            </PinkButton>
-                          </div>
-                        )}
+                          {/* Only show the delete button if we've got more than 1 block */}
+                          {values.tissues[currentIndex].blocks.length > 1 && (
+                            <div className="flex justify-end">
+                              <FieldArray name={`tissues.${currentIndex}.blocks`}>
+                                {(blockHelpers) => (
+                                  <PinkButton
+                                    type="button"
+                                    action="tertiary"
+                                    onClick={() => {
+                                      blockHelpers.remove(blockIndex);
+                                    }}
+                                  >
+                                    {`Delete ${keywords.get('Block') ?? 'Block'}`}
+                                  </PinkButton>
+                                )}
+                              </FieldArray>
+                            </div>
+                          )}
+                        </div>
                       </motion.div>
                     );
                   })}

--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -356,6 +356,24 @@ const RegistrationForm = <T extends TissueValues<B>, B>({
                     behavior: 'smooth'
                   });
                 }}
+                onIdenticalTissueButton={() => {
+                  tissueHelpers.push(values.tissues[currentIndex]);
+                  values.tissues[currentIndex].blocks.forEach((block, indx) => {
+                    setFieldValue(`tissues[${currentIndex + 1}].blocks[${indx}].solution`, '');
+                    setFieldValue(`tissues[${currentIndex + 1}].blocks[${indx}].fixative`, '');
+                    setFieldValue(`tissues[${currentIndex + 1}].blocks[${indx}].replicateNumber`, '');
+                    setFieldValue(`tissues[${currentIndex + 1}].blocks[${indx}].externalIdentifier`, '');
+                    setFieldValue(
+                      `tissues[${currentIndex + 1}].blocks[${indx}].spatialLocation`,
+                      values.tissues[currentIndex].blocks[indx].spatialLocation
+                    );
+                  });
+
+                  setCurrentIndex(currentIndex + 1);
+                  tissueRef.current?.scrollIntoView({
+                    behavior: 'smooth'
+                  });
+                }}
                 keywordsMap={keywordsMap}
               />
             )}

--- a/src/pages/registration/RegistrationForm.tsx
+++ b/src/pages/registration/RegistrationForm.tsx
@@ -245,7 +245,8 @@ const RegistrationForm = <T extends TissueValues<B>, B>({
                                   action="secondary"
                                   className="mt-4 inline-flex"
                                   onClick={() => {
-                                    //Create new sample fields refilled with the sample from which this is invoked. Reset Solution,Fixative and Replicate Number fields
+                                    //Create new duplicate sample with sample fields refilled using the sample from which it is created.
+                                    //Reset Solution,Fixative and Replicate Number,External Identifier fields
                                     blockHelpers.push(block);
                                     setFieldValue(
                                       `tissues[${currentIndex}].blocks[${values.tissues[currentIndex].blocks.length}].solution`,
@@ -257,6 +258,10 @@ const RegistrationForm = <T extends TissueValues<B>, B>({
                                     );
                                     setFieldValue(
                                       `tissues[${currentIndex}].blocks[${values.tissues[currentIndex].blocks.length}].replicateNumber`,
+                                      ''
+                                    );
+                                    setFieldValue(
+                                      `tissues[${currentIndex}].blocks[${values.tissues[currentIndex].blocks.length}].externalIdentifier`,
                                       ''
                                     );
                                     scrollToLatestBlock();

--- a/src/pages/registration/SummaryBox.tsx
+++ b/src/pages/registration/SummaryBox.tsx
@@ -52,6 +52,7 @@ interface SummaryBoxParams {
   errors: FormikErrors<RegistrationFormValues>;
   touched: FormikTouched<RegistrationFormValues>;
   onNewTissueButton: () => void;
+  onIdenticalTissueButton: () => void;
   currentFormIndex: number;
   setCurrentFormIndex: (n: number) => void;
   keywordsMap?: Map<TextType, string>;
@@ -63,6 +64,7 @@ const SummaryBox = ({
   errors,
   touched,
   onNewTissueButton,
+  onIdenticalTissueButton,
   currentFormIndex,
   setCurrentFormIndex,
   keywordsMap
@@ -151,6 +153,23 @@ const SummaryBox = ({
           }}
         >
           + Add Another Tissue
+        </WhiteButton>
+        <WhiteButton
+          disabled={whiteButtonDisabled}
+          type="button"
+          action="primary"
+          className="mt-2 w-full"
+          onClick={(e) => {
+            e.preventDefault();
+            if (whiteButtonDisabled) {
+              return;
+            }
+            setWhiteButtonDisabled(true);
+            onIdenticalTissueButton();
+            setTimeout(() => setWhiteButtonDisabled(false), 1500);
+          }}
+        >
+          + Add Identical Tissue
         </WhiteButton>
 
         {}


### PR DESCRIPTION
Register multiple pots for same donor, spatial location and tissue type
 - 'Add Identical Tissue Sample' button to create duplicate samples
 -  'Add Identical Tissue' button to create duplicate tissues
 - Copy Spatial location and labware type fields to duplicate sample
 - Empty External identifier, Replicate number, Fixative and Solution fields in duplicate sample