### PR TITLE
Fixative selection in Pot processing

### DIFF
--- a/src/components/originalSampleProcessing/potProcessing/PotProcessingLabwarePlan.tsx
+++ b/src/components/originalSampleProcessing/potProcessing/PotProcessingLabwarePlan.tsx
@@ -106,10 +106,14 @@ const PotProcessingLabwarePlan = React.forwardRef<HTMLDivElement, PotProcessingL
       if (outputLabware) {
         setFieldValue(`plans.${rowIndex}.labwareType`, outputLabware.labwareType.name);
       }
-      setFieldValue(
-        `plans.${rowIndex}.fixative`,
-        outputLabware.labwareType.name === LabwareTypeName.FETAL_WASTE_CONTAINER ? 'None' : fixative
-      );
+
+      //Initialize with selected fixative only during creation
+      if (!values.plans[rowIndex]) {
+        setFieldValue(
+          `plans.${rowIndex}.fixative`,
+          outputLabware.labwareType.name === LabwareTypeName.FETAL_WASTE_CONTAINER ? 'None' : fixative
+        );
+      }
     }, [setFieldValue, rowIndex, fixative, outputLabware, sourceLabware]);
 
     return (

--- a/src/components/originalSampleProcessing/potProcessing/PotProcessingLabwarePlan.tsx
+++ b/src/components/originalSampleProcessing/potProcessing/PotProcessingLabwarePlan.tsx
@@ -114,7 +114,7 @@ const PotProcessingLabwarePlan = React.forwardRef<HTMLDivElement, PotProcessingL
           outputLabware.labwareType.name === LabwareTypeName.FETAL_WASTE_CONTAINER ? 'None' : fixative
         );
       }
-    }, [setFieldValue, rowIndex, fixative, outputLabware, sourceLabware]);
+    }, [values, setFieldValue, rowIndex, fixative, outputLabware, sourceLabware]);
 
     return (
       <motion.div


### PR DESCRIPTION
Selecting a fixative in 'Add labware' panel dropdown should not change fixatives for already created plans

