### PR TITLE
x938 - Changes to fix cypress test flaking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   cypress:
     name: Run cypress tests
     runs-on: ubuntu-latest
-    container: cypress/included:9.4.1
+    container: cypress/browsers:node16.17.1-chrome106-ff105-edge
     steps:
       - uses: actions/checkout@v2
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
   cypress:
     name: Run cypress tests
     runs-on: ubuntu-latest
-    container: cypress/browsers:node16.17.1-chrome106-ff105-edge
+    container: 
+      image: cypress/browsers:node16.17.1-chrome106-ff105-edge
+      options: --user 1001
     steps:
       - uses: actions/checkout@v2
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
   cypress:
     name: Run cypress tests
     runs-on: ubuntu-latest
+    container: cypress/browsers:chrome69
     steps:
       - uses: actions/checkout@v2
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   cypress:
     name: Run cypress tests
     runs-on: ubuntu-latest
-    container: cypress/browsers:chrome69
+    container: cypress/included:9.4.1
     steps:
       - uses: actions/checkout@v2
         name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           install-command: yarn --frozen-lockfile --silent
           build: yarn build
-          start: yarn start
+          start: npx serve -s build -p 3000
           wait-on: "http://localhost:3000"
           config: baseUrl=http://localhost:3000
           timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,11 @@ jobs:
         with:
           install-command: yarn --frozen-lockfile --silent
           build: yarn build
-          start: npx serve -s build -p 3000
+          start: yarn start
           wait-on: "http://localhost:3000"
           config: baseUrl=http://localhost:3000
           timeout-minutes: 5
+          browser: chrome
 
   jest:
     name: Run unit tests


### PR DESCRIPTION
Closes #227 

Previously cypress was running off electron, in theory this could have caused the difference in github CI to local tests as locally we use chrome.

Running off chrome appears to make the tests 1-2 mins slower.

In future we may need to upgrade the docker image to the latest versions of chrome using https://github.com/cypress-io/cypress-docker-images

Flakiness is difficult to test but so far this PR has **passed 5/5** re-runs of cypress tests.

