### PR TITLE
X800 history file view

### DIFF
--- a/cypress/e2e/pages/fileManager.cy.ts
+++ b/cypress/e2e/pages/fileManager.cy.ts
@@ -187,7 +187,7 @@ describe('FileManager', () => {
         selectFile();
         uploadButton().click();
       });
-      it('should displau upload failure message', () => {
+      it('should display upload failure message', () => {
         cy.findByTestId('error-div').should('exist');
       });
     });

--- a/cypress/e2e/pages/fileManager.cy.ts
+++ b/cypress/e2e/pages/fileManager.cy.ts
@@ -19,6 +19,10 @@ describe('FileManager', () => {
       it('should select SGP1008 in select box', () => {
         workNumber().should('have.value', 'SGP1008');
       });
+      it('should  enable file selection button', () => {
+        cy.get('input[type=file]').should('be.enabled');
+        cy.findByText('Please select an SGP Number to enable file selection').should('not.exist');
+      });
       it('should display a table with files uploaded for the selected SGP Numbers', () => {
         cy.findByRole('table').should('exist');
         cy.findByRole('table').find('tr').should('have.length.above', 0);
@@ -54,6 +58,15 @@ describe('FileManager', () => {
       it('should not display a table', () => {
         cy.findByRole('table').should('not.exist');
         cy.findByText('No files uploaded for SGP1008').should('be.visible');
+      });
+    });
+    context('on removing SGP Number selection', () => {
+      before(() => {
+        cy.visit('/file_manager');
+      });
+      it('should  disable file selection button', () => {
+        cy.get('input[type=file]').should('be.disabled');
+        cy.findByText('Please select an SGP Number to enable file selection').should('be.visible');
       });
     });
   });

--- a/cypress/e2e/pages/history.cy.ts
+++ b/cypress/e2e/pages/history.cy.ts
@@ -110,6 +110,18 @@ describe('History Page', () => {
         cy.findByTestId('history').should('exist');
         cy.findByTextContent('History for Work Number SGP1');
       });
+      it('displays uploaded files section', () => {
+        cy.findByText('Uploaded files for SGP1').should('be.visible');
+      });
+    });
+
+    context('when clicking on uploaded files link', () => {
+      before(() => {
+        cy.contains('Uploaded files for SGP1').click();
+      });
+      it('goes to file manager page for SGP1', () => {
+        cy.url().should('be.equal', 'http://localhost:3000/file_manager/?workNumber=SGP1');
+      });
     });
   });
 

--- a/src/components/history/History.tsx
+++ b/src/components/history/History.tsx
@@ -75,6 +75,22 @@ export default function History(props: HistoryProps) {
         }
       },
       {
+        Header: 'Uploaded files',
+        accessor: 'destinationBarcode',
+        Cell: (props: Cell<HistoryTableEntry>) => {
+          const barcode = props.row.original.destinationBarcode;
+          let classes =
+            historyProps.kind === 'labwareBarcode' && barcode === historyProps.value
+              ? 'bg-yellow-400 text-sp-600 hover:text-sp-700 font-semibold hover:underline text-base tracking-wide'
+              : '';
+          return (
+            <StyledLink to={`/labware/${barcode}`} className={classes ? classes : undefined}>
+              {barcode}
+            </StyledLink>
+          );
+        }
+      },
+      {
         Header: 'Donor ID',
         accessor: 'donorName'
       },

--- a/src/components/upload/FileUploader.tsx
+++ b/src/components/upload/FileUploader.tsx
@@ -7,6 +7,7 @@ import FileIcon from '../icons/FileIcon';
 import FailIcon from '../icons/FailIcon';
 import { ConfirmationModal } from '../modal/ConfirmationModal';
 import UploadIcon from '../icons/UploadIcon';
+import MutedText from '../MutedText';
 
 export type ConfirmUploadProps = {
   confirmMessage: string;
@@ -87,16 +88,28 @@ const FileUploader: React.FC<FileUploaderProps> = ({ url, enableUpload, confirmU
 
   return (
     <div className={'mx-auto  max-w-screen-lg bg-gray-100 border border-gray-200 bg-gray-100 rounded-md'}>
-      <div className="flex flex-row border-b-2 border-gray-200 space-x-4 py-2" data-testid={'upload'}>
-        <Input type="file" id="file" onChange={onFileChange} data-testid="file-input" className="hidden" />
-        <label
-          htmlFor="file"
-          className={
-            'bg-gray-100 border-2 border-gray-200 whitespace-nowrap hover:bg-gray-200 text-black  py-2 px-4 rounded'
-          }
-        >
-          Select file...
-        </label>
+      <div className="flex flex-col border-b-2 border-gray-200 space-x-6 py-2" data-testid={'upload'}>
+        <div className="flex flex-row space-x-4">
+          <Input
+            type="file"
+            id="file"
+            disabled={!url}
+            onChange={onFileChange}
+            data-testid="file-input"
+            className="hidden"
+          />
+          <label
+            htmlFor="file"
+            className={`${
+              url ? 'bg-gray-200 text-black hover:bg-gray-300 border-2 border-gray-200' : 'bg-white text-gray-400'
+            }  whitespace-nowrap  py-2 px-4 rounded`}
+          >
+            Select file...
+          </label>
+        </div>
+        {!url && (
+          <MutedText className={'text-gray-600'}>Please select an SGP Number to enable file selection</MutedText>
+        )}
       </div>
       {file && (
         <div

--- a/src/pages/FileManager.tsx
+++ b/src/pages/FileManager.tsx
@@ -42,6 +42,7 @@ const FileManager: React.FC<FileManagerProps> = ({ workNumbers }: FileManagerPro
 
   /**Upload URL**/
   const memoURL = React.useMemo(() => {
+    if (!workNumber) return '';
     return `/files?workNumber=${encodeURIComponent(workNumber)}`;
   }, [workNumber]);
 

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -62,6 +62,7 @@ export default function History() {
               </Form>
             </Formik>
           </div>
+
           {historyProps && <HistoryComponent {...historyProps} />}
         </div>
       </AppShell.Main>


### PR DESCRIPTION
Accessing Uploaded files from history page
- If history search is by workNumber, the uploaded file section is displayed as a separate section 
- Otherwise, uploaded files will be displayed as a column in history table where each column entry will navigate to the files uploaded for the corresponding work number.
- Test case updation
- Improvements in file upload component.
