### PR TITLE
Make grid-based storage still work without specified grid-direction

### DIFF
--- a/src/lib/services/searchService.ts
+++ b/src/lib/services/searchService.ts
@@ -1,4 +1,4 @@
-import { FindQuery, FindRequest } from '../../types/sdk';
+import { FindQuery, FindRequest, GridDirection } from '../../types/sdk';
 import { SearchResultsType, SearchResultTableEntry } from '../../types/stan';
 import _ from 'lodash';
 import { addressToLocationAddress } from '../helpers/locationHelper';
@@ -68,8 +68,12 @@ export class SearchService implements SearchServiceInterface<FindRequest, Search
                 barcode: location.barcode,
                 displayName: location.qualifiedNameWithFirstBarcode ?? location.barcode,
                 address:
-                  labwareLocation?.address && location?.direction && location?.size
-                    ? addressToLocationAddress(labwareLocation?.address, location.size, location.direction)
+                  labwareLocation?.address && location?.size
+                    ? addressToLocationAddress(
+                        labwareLocation?.address,
+                        location.size,
+                        location.direction ?? GridDirection.DownRight
+                      )
                     : null
               },
         sectionNumber: sample.section,

--- a/src/pages/Location.tsx
+++ b/src/pages/Location.tsx
@@ -23,7 +23,7 @@ import {
 import { Authenticated, Unauthenticated } from '../components/Authenticated';
 import { RouteComponentProps } from 'react-router-dom';
 import { extractServerErrors, LocationMatchParams, LocationSearchParams } from '../types/stan';
-import { LocationFieldsFragment, Maybe, StoreInput, UserRole } from '../types/sdk';
+import { GridDirection, LocationFieldsFragment, Maybe, StoreInput, UserRole } from '../types/sdk';
 import { useMachine } from '@xstate/react';
 import { StoredItemFragment } from '../lib/machines/locations/locationMachineTypes';
 import createLocationMachine from '../lib/machines/locations/locationMachine';
@@ -70,10 +70,9 @@ interface LocationProps extends RouteComponentProps<LocationMatchParams> {
 const Location: React.FC<LocationProps> = ({ storageLocation, locationSearchParams, match }) => {
   const locationMachine = React.useMemo(() => {
     // Create all the possible addresses for this location if it has a size.
-    const locationAddresses: Map<string, number> =
-      storageLocation.size && storageLocation.direction
-        ? buildOrderedAddresses(storageLocation.size, storageLocation.direction)
-        : new Map<string, number>();
+    const locationAddresses: Map<string, number> = storageLocation.size
+      ? buildOrderedAddresses(storageLocation.size, storageLocation.direction ?? GridDirection.DownRight)
+      : new Map<string, number>();
 
     // Create a map of location address to item
     const addressToItemMap = new Map<string, StoredItemFragment>();
@@ -418,11 +417,11 @@ const Location: React.FC<LocationProps> = ({ storageLocation, locationSearchPara
               <Success className="mb-5" key={labwareBarcode} message={`Labware found`}>
                 Labware <span className="font-bold">{labwareBarcode}</span> is in address{' '}
                 <span className="font-bold">
-                  {location.size && location.direction
+                  {location.size
                     ? addressToLocationAddress(
                         labwareBarcodeToAddressMap.get(labwareBarcode) ?? '',
                         location.size,
-                        location.direction
+                        location.direction ?? GridDirection.DownRight
                       )
                     : labwareBarcodeToAddressMap.get(labwareBarcode)}
                 </span>

--- a/src/pages/location/ItemsGrid.tsx
+++ b/src/pages/location/ItemsGrid.tsx
@@ -9,7 +9,7 @@ import BarcodeIcon from '../../components/icons/BarcodeIcon';
 import { Authenticated } from '../../components/Authenticated';
 import Table, { TableBody, TableCell, TableHead, TableHeader } from '../../components/Table';
 import { getLabwareInLocation } from '../../lib/services/locationService';
-import { LabwareFieldsFragment, SuggestedWorkFieldsFragment, UserRole } from '../../types/sdk';
+import { GridDirection, LabwareFieldsFragment, SuggestedWorkFieldsFragment, UserRole } from '../../types/sdk';
 import { tissue } from '../../lib/helpers/labwareHelper';
 import { stanCore } from '../../lib/sdk';
 
@@ -69,7 +69,12 @@ export const ItemsGrid: React.FC = () => {
           <div className="ml-2 md:w-2/3 lg:w-1/2 ">
             {selectedAddress && (
               <span>
-                Selected Address: {addressToLocationAddress(selectedAddress, location.size!, location.direction!)}
+                Selected Address:{' '}
+                {addressToLocationAddress(
+                  selectedAddress,
+                  location.size!,
+                  location.direction ?? GridDirection.DownRight
+                )}
               </span>
             )}
             <ScanInput

--- a/src/pages/location/ItemsList.tsx
+++ b/src/pages/location/ItemsList.tsx
@@ -9,7 +9,7 @@ import MutedText from '../../components/MutedText';
 import { addressToLocationAddress } from '../../lib/helpers/locationHelper';
 import { Authenticated } from '../../components/Authenticated';
 import { getLabwareInLocation } from '../../lib/services/locationService';
-import { LabwareFieldsFragment, Maybe, SuggestedWorkFieldsFragment, UserRole } from '../../types/sdk';
+import { GridDirection, LabwareFieldsFragment, Maybe, SuggestedWorkFieldsFragment, UserRole } from '../../types/sdk';
 import { tissue } from '../../lib/helpers/labwareHelper';
 import { stanCore } from '../../lib/sdk';
 
@@ -102,8 +102,12 @@ export const ItemsList: React.FC<ItemsListParams> = () => {
                 <TableCell>
                   {item.address ? (
                     <span className="font-bold">
-                      {location.size && location.direction
-                        ? addressToLocationAddress(item.address, location.size!, location.direction!)
+                      {location.size
+                        ? addressToLocationAddress(
+                            item.address,
+                            location.size!,
+                            location.direction ?? GridDirection.DownRight
+                          )
                         : item.address}
                     </span>
                   ) : (


### PR DESCRIPTION
Currently grid-based locations don't work if they do not specify a grid-direction.