### PR TITLE
x1015: remove some location barcodes from the store page

### DIFF
--- a/src/static/store.json
+++ b/src/static/store.json
@@ -2,9 +2,6 @@
   "locationType": {
     "Room Temperature": [
       {
-        "barcode": "STO-005B"
-      },
-      {
         "barcode": "STO-003D"
       },
       {
@@ -33,12 +30,6 @@
       },
       {
         "barcode": "STO-001F"
-      },
-      {
-        "barcode": "STO-0EF7"
-      },
-      {
-        "barcode": "STO-1333"
       },
       {
         "barcode": "STO-1807"


### PR DESCRIPTION
For https://github.com/sanger/storelight-sql/issues/3

See also https://github.com/sanger/storelight-sql/blob/master/x1015_revise_locations.sql