### PR TITLE
x1174 Allow certain characters in replicate number

### DIFF
--- a/cypress/e2e/shared/registration.cy.ts
+++ b/cypress/e2e/shared/registration.cy.ts
@@ -69,13 +69,13 @@ export function shouldBehaveLikeARegistrationForm(registrationType: Registration
     );
 
     it('requires Replicate Number to be an alphanumeric string of maximum length 7 ', () => {
-      cy.findByTestId('Replicate Number').type('1.1').blur();
+      cy.findByTestId('Replicate Number').type('1+1').blur();
       checkReplicateWarningIsVisible();
 
-      cy.findByTestId('Replicate Number').clear().type('1ab-').blur();
+      cy.findByTestId('Replicate Number').clear().type('1ab!').blur();
       checkReplicateWarningIsVisible();
 
-      cy.findByTestId('Replicate Number').clear().type('1ab67896').blur();
+      cy.findByTestId('Replicate Number').clear().type('1ab67896df.').blur();
       checkReplicateWarningIsVisible();
 
       cy.findByTestId('Replicate Number').clear().type('1ab678A').blur();

--- a/cypress/e2e/shared/registration.cy.ts
+++ b/cypress/e2e/shared/registration.cy.ts
@@ -79,7 +79,9 @@ export function shouldBehaveLikeARegistrationForm(registrationType: Registration
       checkReplicateWarningIsVisible();
 
       cy.findByTestId('Replicate Number').clear().type('1ab678A').blur();
-      cy.findByText('Replicate number must be a string of up to 7 letters and numbers.').should('not.exist');
+      cy.findByText(
+        'Replicate number must be a string of letters and numbers, with isolated hyphens, underscores or full stops.'
+      ).should('not.exist');
     });
 
     it('requires Fixative', () => {
@@ -105,6 +107,8 @@ export function shouldBehaveLikeARegistrationForm(registrationType: Registration
     }
   });
   const checkReplicateWarningIsVisible = () => {
-    cy.findByText('Replicate number must be a string of up to 7 letters and numbers.').should('be.visible');
+    cy.findByText(
+      'Replicate number must be a string of letters and numbers, with isolated hyphens, underscores or full stops.'
+    ).should('be.visible');
   };
 }

--- a/cypress/e2e/shared/registration.cy.ts
+++ b/cypress/e2e/shared/registration.cy.ts
@@ -68,7 +68,7 @@ export function shouldBehaveLikeARegistrationForm(registrationType: Registration
       }
     );
 
-    it('requires Replicate Number to be an alphanumeric string of maximum length 7 ', () => {
+    it('requires Replicate Number to be suitable', () => {
       cy.findByTestId('Replicate Number').type('1+1').blur();
       checkReplicateWarningIsVisible();
 

--- a/src/lib/validation/registrationValidation.ts
+++ b/src/lib/validation/registrationValidation.ts
@@ -124,14 +124,14 @@ export default class RegistrationValidation {
     if (this.tissueSampleRegistration) {
       return validation.optionalString({
         label: 'Replicate Number',
-        restrictChars: /^[0-9a-z]([-_.]?[0-9a-z])$/i,
+        restrictChars: /^[0-9a-z]([-_.]?[0-9a-z])*$/i,
         errorMessage:
           'Replicate number must be a string of letters and numbers, with isolated hyphens, underscores or full stops.'
       });
     } else {
       return validation.requiredString({
         label: 'Replicate Number',
-        restrictChars: /^[0-9a-z]([-_.]?[0-9a-z])$/i,
+        restrictChars: /^[0-9a-z]([-_.]?[0-9a-z])*$/i,
         errorMessage:
           'Replicate number must be a string of letters and numbers, with isolated hyphens, underscores or full stops.'
       });

--- a/src/lib/validation/registrationValidation.ts
+++ b/src/lib/validation/registrationValidation.ts
@@ -124,14 +124,16 @@ export default class RegistrationValidation {
     if (this.tissueSampleRegistration) {
       return validation.optionalString({
         label: 'Replicate Number',
-        restrictChars: /^[a-zA-Z0-9]{1,7}$/,
-        errorMessage: 'Replicate number must be a string of up to 7 letters and numbers.'
+        restrictChars: /^[0-9a-z]([-_.]?[0-9a-z])$/i,
+        errorMessage:
+          'Replicate number must be a string of letters and numbers, with isolated hyphens, underscores or full stops.'
       });
     } else {
       return validation.requiredString({
         label: 'Replicate Number',
-        restrictChars: /^[a-zA-Z0-9]{1,7}$/,
-        errorMessage: 'Replicate number must be a string of up to 7 letters and numbers.'
+        restrictChars: /^[0-9a-z]([-_.]?[0-9a-z])$/i,
+        errorMessage:
+          'Replicate number must be a string of letters and numbers, with isolated hyphens, underscores or full stops.'
       });
     }
   }


### PR DESCRIPTION
Can contain _-. (underscore, hyphen, full stop) in addition to letters and digits.
Must start and end with a letter or digit.
Cannot have two adjacent punctuation characters.

For https://github.com/sanger/stan-core/issues/351