### PR TITLE
Rt 806566 transfer operation

### DIFF
--- a/cypress/e2e/pages/libraryAmpAndGeneration.cy.ts
+++ b/cypress/e2e/pages/libraryAmpAndGeneration.cy.ts
@@ -16,6 +16,15 @@ describe('LibraryAmpAndGeneration Page', () => {
       cy.visit('/lab/libraryGeneration');
       selectSGPNumber('SGP1008');
     });
+    describe('When updating the destination selection mode', () => {
+      before(() => {
+        cy.get('[type="radio"][name="8 Strip Tube"]').check();
+        cy.get('[type="radio"][name="96 Well Plate"]').check();
+      });
+      it('does not append destination plates', () => {
+        cy.findByTestId('pager-text-div').contains('1 of 1');
+      });
+    });
     describe('Mapping Source with 8 Strip Tube Output labware', () => {
       describe('When all required fields for mapping are fulfilled', () => {
         before(() => {

--- a/cypress/e2e/pages/visiumTransfer.cy.ts
+++ b/cypress/e2e/pages/visiumTransfer.cy.ts
@@ -22,6 +22,19 @@ describe('Transfer Page', () => {
       });
     });
 
+    describe('when scanning the labware, before selecting the destination labware', () => {
+      before(() => {
+        cy.get('#inputLabwares').within((elem) => {
+          cy.wrap(elem).get('#labwareScanInput').wait(1000).clear().type('STAN-3111{enter}');
+        });
+      });
+      it('shows the scanned labware', () => {
+        cy.get('#inputLabwares').within((elem) => {
+          cy.wrap(elem).findByText('A1').should('be.visible');
+        });
+      });
+    });
+
     it('should display 96 Well Plate layout when user selects 96 Well Plate option', () => {
       cy.get('[type="radio"][name="96 Well Plate"]').check();
       cy.findByTestId('bioState').should('be.visible');
@@ -79,6 +92,32 @@ describe('Transfer Page', () => {
       cy.findByTestId('removeButton').click();
       cy.findByText('STAN-3112').should('not.exist');
       cy.findByTestId('removeButton').should('not.exist');
+    });
+  });
+
+  describe('Multiple destinations with different labware type', () => {
+    before(() => {
+      cy.get('[type="radio"][name="96 Well Plate"]').check();
+      cy.get('[type="radio"][name="8 Strip Tube"]').check();
+    });
+    it('updates destination pagination accordingly', () => {
+      cy.findByTestId('pager-text-div').contains('2 of 2');
+    });
+    describe('when paginating to a different destination labware type', () => {
+      before(() => {
+        cy.findByTestId('left-button').click();
+      });
+      it('updates the selection mode accordingly', () => {
+        cy.findByTestId('96 Well Plate').should('be.checked');
+      });
+    });
+    describe('when selecting scan labware option', () => {
+      before(() => {
+        cy.get('[type="radio"][name="Scan Labware"]').check();
+      });
+      it('resets the destination labware', () => {
+        cy.findByTestId('pager-text-div').contains('1 of 1');
+      });
     });
   });
 

--- a/cypress/e2e/pages/visiumTransfer.cy.ts
+++ b/cypress/e2e/pages/visiumTransfer.cy.ts
@@ -116,7 +116,7 @@ describe('Transfer Page', () => {
         cy.get('[type="radio"][name="Scan Labware"]').check();
       });
       it('resets the destination labware', () => {
-        cy.findByTestId('pager-text-div').contains('1 of 1');
+        cy.findByTestId('pager-text-div').should('not.exist');
       });
     });
   });

--- a/src/components/libraryGeneration/SlotCopyComponent.tsx
+++ b/src/components/libraryGeneration/SlotCopyComponent.tsx
@@ -132,7 +132,7 @@ export const SlotCopyDestinationConfigPanel: React.FC<DestinationLabwareScanPane
               locked={labware?.labware.barcode !== undefined}
               checkForCleanedOutAddresses
             >
-              {({ labwares, removeLabware, cleanedOutAddresses }) => {
+              {({ labwares, removeLabware }) => {
                 return (
                   <div className="flex flex-col">
                     {labwares.length > 0 && (
@@ -310,10 +310,11 @@ function SlotCopyComponent({
           hideProgressBar: true
         });
       }
-      labware =
-        !containsScannedLabware(destinations) && newLabware.length > 0
+      labware = addPlateOption
+        ? !containsScannedLabware(destinations) && newLabware.length > 0
           ? [...destinations.map((dest) => dest.labware), ...newLabware]
-          : newLabware;
+          : newLabware
+        : newLabware;
 
       send({ type: 'UPDATE_DESTINATION_LABWARE', labware });
       send({ type: 'UPDATE_DESTINATION_SELECTION_MODE', mode });
@@ -381,6 +382,22 @@ function SlotCopyComponent({
     cleanedOutInputAddresses.set(source.labware.id, source.cleanedOutAddresses ?? []);
   });
 
+  const updateDestinationModeWhenPaginating = () => {
+    //Before selecting any destination
+    if (!destinationSelectionMode.current) {
+      return undefined;
+    }
+    if (destinationSelectionMode.current === DestinationSelectionMode.SCAN) {
+      return destinationSelectionMode.current;
+    }
+    if (selectedDestination.labwareType.name === '96 well plate') {
+      destinationSelectionMode.current = DestinationSelectionMode.PLATE;
+      return DestinationSelectionMode.PLATE;
+    }
+    destinationSelectionMode.current = DestinationSelectionMode.STRIP_TUBE;
+    return DestinationSelectionMode.STRIP_TUBE;
+  };
+
   return (
     <>
       <div className="mx-auto">
@@ -412,7 +429,7 @@ function SlotCopyComponent({
               onLabwareScan={onDestinationLabwareScan}
               onDestinationSelectionModeChange={onDestinationSelectionModeChange}
               labware={destinations.find((dest) => dest.labware.id === selectedDestination.id)}
-              destinationSelectionMode={destinationSelectionMode.current}
+              destinationSelectionMode={updateDestinationModeWhenPaginating()}
             />
           }
           onSelectInputLabware={setSelectedSource}

--- a/src/components/slotMapper/SlotMapper.tsx
+++ b/src/components/slotMapper/SlotMapper.tsx
@@ -186,9 +186,6 @@ const SlotMapper: React.FC<ExtendedSlotMapperProps> = ({
 
   const getSourceSlotColor = useCallback(
     (labware: LabwareFlaggedFieldsFragment, address: string, slot: SlotFieldsFragment) => {
-      if (!currentOutput) {
-        return 'bg-white';
-      }
       if (selectedCopyMode === SlotCopyMode.ONE_TO_MANY) {
         if (oneToManyCopyInProgress && selectedInputAddresses[0] === address) {
           return `bg-${colorByBarcode.get(labware.barcode)}-500 ring ring-pink-600 ring-offset-2`;
@@ -196,7 +193,7 @@ const SlotMapper: React.FC<ExtendedSlotMapperProps> = ({
       }
       //Slots copied between current selected source and destination labware
       if (
-        find(currentOutput.slotCopyContent, {
+        find(currentOutput && currentOutput.slotCopyContent, {
           sourceBarcode: labware.barcode,
           sourceAddress: address
         })
@@ -291,7 +288,7 @@ const SlotMapper: React.FC<ExtendedSlotMapperProps> = ({
   }, [currentInputPage, inputLabware, onSelectInputLabware, setCurrentInputLabware]);
 
   /**
-   * Whenever the number of input labwares changes, set the number of pages on the pager
+   * Whenever the number of output labwares changes, set the number of pages on the pager
    */
   const numberOfOutputLabware = outputSlotCopies.length;
   useEffect(() => {
@@ -299,7 +296,7 @@ const SlotMapper: React.FC<ExtendedSlotMapperProps> = ({
   }, [numberOfOutputLabware, setNumberOfOutputPages]);
 
   /**
-   * Whenever the number of input labwares increases, go to the last page
+   * Whenever the number of output labwares increases, go to the last page
    */
   const previousOutputLength = usePrevious(outputSlotCopies.length);
   useEffect(() => {
@@ -313,8 +310,10 @@ const SlotMapper: React.FC<ExtendedSlotMapperProps> = ({
    * and also notify parent using callback function
    */
   useEffect(() => {
-    if (outputSlotCopies.length === 0 || currentOutputPage <= 0 || outputSlotCopies.length <= currentOutputPage - 1)
+    if (outputSlotCopies.length === 0 || currentOutputPage <= 0 || outputSlotCopies.length <= currentOutputPage - 1) {
+      setCurrentOutput(null); // To Reset the output labware when selecting SCAN labware mode, before scanning a labware
       return;
+    }
     setCurrentOutput(outputSlotCopies[currentOutputPage - 1]);
     //Notify parent using callback
     onSelectOutputLabware?.(outputSlotCopies[currentOutputPage - 1].labware);


### PR DESCRIPTION
- Populate the source labware with its samples correctly, even before selecting a destination labware.
- Update the 'Output Labware Selection' checkbox accordingly to match the displayed labware in cases where there are multiple destination labware and the user is paginating through them.
- Fix a Visual bug in the Library generation operation, where when the user selects a different destination labware type, the pagination footer gets updated (i.e 2 of 2) even though only one destination labware is taken on consideration.