### PR TITLE
RT#807917 measurement input field is too narrow

### DIFF
--- a/src/components/slotMeasurement/SlotMeasurements.tsx
+++ b/src/components/slotMeasurement/SlotMeasurements.tsx
@@ -133,6 +133,7 @@ const SlotMeasurements = ({ slotMeasurements, measurementConfig, onChangeField, 
                   }}
                   validate={measurementProp.validateFunction}
                   min={0}
+                  style={{ minWidth: '5em' }}
                   step={measurementProp.stepIncrement}
                 />
               </>


### PR DESCRIPTION
Set the minimum width of the input field to 5em (allowing space for the up/down buttons).

For #738 