### PR TITLE
RT#807924 Use correct name from core when adding config option

### DIFF
--- a/src/components/workAllocation/AddNewConfigOption.tsx
+++ b/src/components/workAllocation/AddNewConfigOption.tsx
@@ -11,7 +11,7 @@ import { Maybe } from 'yup';
 
 export type AddNewConfigOptionProps = {
   inputRef: React.RefObject<HTMLInputElement>;
-  onSuccess: () => void;
+  onSuccess: (object: any) => void;
   onSubmit: (value: string) => Promise<any>;
   onFinish: () => void;
   onCancel: () => void;
@@ -56,7 +56,7 @@ const AddNewConfigOption = (props: AddNewConfigOptionProps) => {
         .then((data) => {
           const success = data && props.returnedDataObject in data && data[props.returnedDataObject] !== null;
           if (success) {
-            props.onSuccess();
+            props.onSuccess(data[props.returnedDataObject]);
             setServerSuccess(`Successfully added new ${props.configName}`);
           } else {
             setServerErrors(`Failed to add new ' ${props.configName}`);

--- a/src/components/workAllocation/WorkAllocation.tsx
+++ b/src/components/workAllocation/WorkAllocation.tsx
@@ -342,12 +342,13 @@ export default function WorkAllocation() {
                     onCancel={() => {
                       setAddNewProjectCodeCode(false);
                     }}
-                    onSuccess={() => {
+                    onSuccess={(object) => {
+                      const name = object.name;
                       send({
                         type: 'ADD_NEWLY_CREATED_PROJECT',
-                        project: projectFactory.build({ name: addNewConfigOptionInputRef.current!.value })
+                        project: projectFactory.build({ name: name })
                       });
-                      setFieldValue('project', addNewConfigOptionInputRef.current!.value);
+                      setFieldValue('project', name);
                     }}
                     onFinish={() => {
                       setAddNewProjectCodeCode(false);
@@ -386,12 +387,13 @@ export default function WorkAllocation() {
                     onCancel={() => {
                       setAddNewOmeroProject(false);
                     }}
-                    onSuccess={async () => {
+                    onSuccess={async (object) => {
+                      const name = object.name;
                       send({
                         type: 'ADD_NEWLY_CREATED_OMERO_PROJECT',
-                        project: omeroProjectFactory.build({ name: addNewConfigOptionInputRef.current!.value })
+                        project: omeroProjectFactory.build({ name: name })
                       });
-                      await setFieldValue('omeroProject', addNewConfigOptionInputRef.current!.value);
+                      await setFieldValue('omeroProject', name);
                     }}
                     onFinish={() => {
                       setAddNewOmeroProject(false);
@@ -444,12 +446,13 @@ export default function WorkAllocation() {
                     onCancel={() => {
                       setAddNewCostCode(false);
                     }}
-                    onSuccess={() => {
+                    onSuccess={(object) => {
+                      const code = object.code;
                       send({
                         type: 'ADD_NEWLY_CREATED_COST_CODE',
-                        costCode: costCodeFactory.build({ code: addNewConfigOptionInputRef.current!.value })
+                        costCode: costCodeFactory.build({ code: code })
                       });
-                      setFieldValue('costCode', addNewConfigOptionInputRef.current!.value);
+                      setFieldValue('costCode', code);
                     }}
                     onFinish={() => {
                       setAddNewCostCode(false);


### PR DESCRIPTION
When adding a config option to the menu in the work allocation page,
use the sanitised version from the core mutation response,
rather than the unsanitised version input by the user.
If there is a better way to do this, please let me know.

For #739