### PR TITLE
x1232: remove two-labware limit on Xenium QC page

### DIFF
--- a/cypress/e2e/pages/xeniumQC.cy.ts
+++ b/cypress/e2e/pages/xeniumQC.cy.ts
@@ -43,9 +43,6 @@ describe('Xenium QC', () => {
       cy.findByTestId('STAN-3112-workNumber').should('exist');
       cy.findByTestId('STAN-3112-comments').should('exist');
     });
-    it('should disable any further labware scanning', () => {
-      cy.get('#labwareScanInput').should('be.disabled');
-    });
   });
   describe('When  two labware is scanned and one is removed', () => {
     before(() => {

--- a/src/pages/XeniumQC.tsx
+++ b/src/pages/XeniumQC.tsx
@@ -208,7 +208,6 @@ const XeniumQC = () => {
                   <FieldArray name={'labware'}>
                     {({ push }) => (
                       <LabwareScanner
-                        limit={2}
                         onAdd={(addedLw) => {
                           const index = values.labware.findIndex((lw) => lw.barcode === addedLw.barcode);
                           if (index < 0) {


### PR DESCRIPTION
For #744 