### PR TITLE
extra UI changes for the cytassist page

### DIFF
--- a/src/components/labware/Labware.tsx
+++ b/src/components/labware/Labware.tsx
@@ -242,8 +242,22 @@ const Labware = ({
     onSelect?.(Array.from(selectedAddresses));
   }, [onSelect, selectedAddresses]);
 
-  const labwareClasses =
-    'inline-block border border-sdb py-2 bg-blue-100 rounded-lg transition duration-300 ease-in-out';
+  const isBarcodeInfoAtTheTop = barcodeInfoPosition === Position.TopLeft || barcodeInfoPosition === Position.TopRight;
+
+  const isBarcodeInfoAtTheBottom =
+    barcodeInfoPosition === Position.BottomRight || barcodeInfoPosition === Position.BottomLeft;
+
+  const isBarcodeInfoAtTheLeft =
+    barcodeInfoPosition === Position.TopLeft || barcodeInfoPosition === Position.BottomLeft;
+
+  const isBarcodeInfoAtTheLeftSide = barcodeInfoPosition === Position.Left;
+
+  const isBarcodeInfoAtTheRightSide = barcodeInfoPosition === Position.Right;
+
+  const labwareDisplayClass =
+    isBarcodeInfoAtTheLeftSide || isBarcodeInfoAtTheRightSide ? 'flex flex row' : 'inline-block';
+
+  const labwareClasses = `${labwareDisplayClass} border border-sdb py-2 bg-blue-100 rounded-lg transition duration-300 ease-in-out items-center`;
 
   const grid =
     labwareDirection && labwareDirection === LabwareDirection.Horizontal
@@ -310,14 +324,6 @@ const Labware = ({
     return slotColumns;
   }, [numColumns, slots]);
 
-  const isBarcodeInfoAtTheTop = barcodeInfoPosition === Position.TopLeft || barcodeInfoPosition === Position.TopRight;
-
-  const isBarcodeInfoAtTheBottom =
-    barcodeInfoPosition === Position.BottomRight || barcodeInfoPosition === Position.BottomLeft;
-
-  const isBarcodeInfoAtTheLeft =
-    barcodeInfoPosition === Position.TopLeft || barcodeInfoPosition === Position.BottomLeft;
-
   const barcodePositionClassName = (): string => {
     if (barcodeInfoPosition && isBarcodeInfoAtTheLeft) return 'items-end';
     return 'items-start';
@@ -326,9 +332,16 @@ const Labware = ({
   const BarcodeInformation = () => (
     <div
       className={
-        'flex flex-col py-2 px-3 text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider ' +
+        'flex flex-col py-2 px-3 text-xs font-medium text-gray-500 uppercase tracking-wider ' +
         barcodePositionClassName()
       }
+      style={{
+        writingMode: isBarcodeInfoAtTheRightSide
+          ? 'vertical-rl'
+          : isBarcodeInfoAtTheLeftSide
+            ? 'vertical-lr'
+            : 'initial'
+      }}
     >
       {name && <span>{name}</span>}
       {barcode && !isFlagged && (
@@ -366,7 +379,7 @@ const Labware = ({
         <SlotColumnInfo slotColumn={slotColumns[0]} slotBuilder={slotBuilder} numRows={numRows} />
       )}
       <div onClick={() => onClick?.()} className={labwareClasses}>
-        {barcodeInfoPosition && isBarcodeInfoAtTheTop && BarcodeInformation()}
+        {(isBarcodeInfoAtTheLeftSide || isBarcodeInfoAtTheTop) && BarcodeInformation()}
         <div className={gridClasses}>
           {buildAddresses({ numColumns, numRows }, gridDirection).map((address, i) => (
             <Slot
@@ -387,7 +400,7 @@ const Labware = ({
             />
           ))}
         </div>
-        {(!barcodeInfoPosition || isBarcodeInfoAtTheBottom) && BarcodeInformation()}
+        {(!barcodeInfoPosition || isBarcodeInfoAtTheBottom || isBarcodeInfoAtTheRightSide) && BarcodeInformation()}
       </div>
       {slotColumns.length > 1 && slotBuilder && (
         <SlotColumnInfo slotColumn={slotColumns[1]} slotBuilder={slotBuilder} numRows={numRows} alignRight={true} />

--- a/src/components/slotMapper/MultipleLabwareSlotMapper.tsx
+++ b/src/components/slotMapper/MultipleLabwareSlotMapper.tsx
@@ -2,7 +2,12 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Labware, { LabwareImperativeRef } from '../labware/Labware';
 import { OutputSlotCopyData, SlotCopyMode, SlotMapperProps } from './slotMapper.types';
 import LabwareScanner from '../labwareScanner/LabwareScanner';
-import { LabwareFlaggedFieldsFragment, SlotFieldsFragment, SlotPassFailFieldsFragment } from '../../types/sdk';
+import {
+  LabwareFlaggedFieldsFragment,
+  LabwareState,
+  SlotFieldsFragment,
+  SlotPassFailFieldsFragment
+} from '../../types/sdk';
 import Heading from '../Heading';
 import MutedText from '../MutedText';
 import { useMachine } from '@xstate/react';
@@ -11,7 +16,7 @@ import Table, { TableBody, TableCell, TableHead, TableHeader } from '../Table';
 import createSlotMapperMachine from './slotMapper.machine';
 import RadioGroup, { RadioButtonInput } from '../forms/RadioGroup';
 import { isSlotFilled } from '../../lib/helpers/slotHelper';
-import { GridDirection, LabwareDirection } from '../../lib/helpers';
+import { GridDirection, LabwareDirection, Position } from '../../lib/helpers';
 import RemoveButton from '../buttons/RemoveButton';
 import Label from '../forms/Label';
 import CustomReactSelect, { OptionType } from '../forms/CustomReactSelect';
@@ -483,6 +488,13 @@ const MultipleLabwareSlotMapper: React.FC<SlotMapperProps> = ({
     [send]
   );
 
+  const isLabwareActive = useCallback(
+    (labwares: LabwareFlaggedFieldsFragment[], foundLabware: LabwareFlaggedFieldsFragment): string[] => {
+      return foundLabware.state !== LabwareState.Active ? [`Labware is not active: [ ${foundLabware.barcode}]`] : [];
+    },
+    []
+  );
+
   /**
    * Callback when the copy mode changes
    */
@@ -532,6 +544,7 @@ const MultipleLabwareSlotMapper: React.FC<SlotMapperProps> = ({
             enableFlaggedLabwareCheck
             checkForCleanedOutAddresses
             initialLabwares={inputLabware}
+            labwareCheckFunction={isLabwareActive}
           >
             {({ removeLabware, cleanedOutAddresses }) => {
               if (inputLabware.length === 0) {
@@ -561,6 +574,7 @@ const MultipleLabwareSlotMapper: React.FC<SlotMapperProps> = ({
                           current.context.cleanedOutInputAddresses?.get(labware.id) ??
                           cleanedOutAddresses?.get(labware.id)
                         }
+                        barcodeInfoPosition={Position.TopRight}
                       />
                       <div>
                         <RemoveButton
@@ -605,8 +619,7 @@ const MultipleLabwareSlotMapper: React.FC<SlotMapperProps> = ({
                 options={[
                   LabwareTypeName.VISIUM_LP_CYTASSIST,
                   LabwareTypeName.VISIUM_LP_CYTASSIST_XL,
-                  LabwareTypeName.VISIUM_LP_CYTASSIST_HD,
-                  LabwareTypeName.STRIP_TUBE
+                  LabwareTypeName.VISIUM_LP_CYTASSIST_HD
                 ].map((key) => {
                   return {
                     label: key,
@@ -644,6 +657,7 @@ const MultipleLabwareSlotMapper: React.FC<SlotMapperProps> = ({
                       cleanedOutAddresses={output.cleanedOutAddresses}
                       gridDirection={GridDirection.LeftUp}
                       labwareDirection={LabwareDirection.Horizontal}
+                      barcodeInfoPosition={Position.Right}
                     />
                   )}
                 </div>

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -93,7 +93,9 @@ export enum Position {
   TopRight = 'TopRight',
   BottomRight = 'BottomRight',
   TopLeft = 'TopLeft',
-  BottomLeft = 'BottomLeft'
+  BottomLeft = 'BottomLeft',
+  Right = 'Right',
+  Left = 'Left'
 }
 
 /**

--- a/src/mocks/handlers/slotCopyHandlers.ts
+++ b/src/mocks/handlers/slotCopyHandlers.ts
@@ -19,7 +19,7 @@ const savedSlotCopy: SlotCopyLoad = {
   operationType: 'CyAssist',
   workNumber: 'SGP1',
   lpNumber: 'LP1',
-  labwareType: LabwareTypeName.STRIP_TUBE,
+  labwareType: LabwareTypeName.VISIUM_LP_CYTASSIST,
   preBarcode: 'H1-9D8VN2V',
   probeLotNumber: '123456',
   lotNumber: '7712543',
@@ -39,7 +39,7 @@ const savedSlotCopy: SlotCopyLoad = {
     {
       sourceBarcode: 'STAN-3200',
       sourceAddress: 'A2',
-      destinationAddress: 'C1'
+      destinationAddress: 'D1'
     }
   ]
 };


### PR DESCRIPTION
Flag non-active labware when scanning
Remove the 8-strip labware type from the CytAssist operation
Barcode information for output labware should be on the right side
Barcode information for input labware should be at the top left side