### PR TITLE
Invalid timestamp in probe hybridisation QC

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "private": true,
   "proxy": "http://localhost:8080",
   "dependencies": {

--- a/src/pages/ProbeHybridisationQC.tsx
+++ b/src/pages/ProbeHybridisationQC.tsx
@@ -112,7 +112,7 @@ export default function ProbeHybridisationQC() {
             ...rq,
             labware: {
               ...rq.labware,
-              completion: formatDateTimeForCore(completionTime)
+              completion: completionTime
             }
           };
         })
@@ -184,7 +184,8 @@ export default function ProbeHybridisationQC() {
             ...omit(data, 'globalComments'),
             labware: [
               {
-                ...data.labware
+                ...data.labware,
+                completion: data.labware.completion ? formatDateTimeForCore(data.labware.completion) : undefined
               }
             ]
           }
@@ -392,7 +393,7 @@ export default function ProbeHybridisationQC() {
                                               ...rq,
                                               labware: {
                                                 ...rq.labware,
-                                                completion: formatDateTimeForCore(e.target.value)
+                                                completion: e.target.value
                                               }
                                             };
                                           } else {


### PR DESCRIPTION
The format_date_time function was called on time change, issue was occurring when the user sends the form with the loaded date-time (without updating it). Moving the format_date_time function to be called before sending the form 