### PR TITLE
x1284 - refactor xenium analyser UI

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -48,8 +48,8 @@ function AppShell({ children }: AppShellParams) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   return (
-    <div className="flex flex-col min-h-screen">
-      <div className={`relative ${config?.headerColor}`}>
+    <div className="flex flex-col min-h-screen sm:min-w-fit">
+      <div className={config?.headerColor}>
         <div className="max-w-7xl mx-auto px-4 sm:px-6">
           <div className="flex justify-between items-center py-4 md:justify-start md:space-x-10 ">
             <div className="flex justify-start">

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -120,10 +120,13 @@ export const TableCell: React.FC<
 
 type Props = {
   children: string | ReactNode | ReactNode[];
+  className?: string;
 };
-export const TabelSubHeader: React.FC<Props> = ({ children, ...rest }) => {
+export const TabelSubHeader: React.FC<Props> = ({ children, className, ...rest }) => {
+  const baseClasses = 'flex text-xs font-medium text-gray-500 uppercase';
+  const classNames = `${baseClasses} ${className ?? ''}`.trim();
   return (
-    <div className="flex text-xs font-medium text-gray-500 uppercase" {...rest}>
+    <div className={classNames} {...rest}>
       {children}
     </div>
   );

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -24,6 +24,7 @@ const FormikInput = ({
   displayTag,
   info,
   preventEnterKeyDefault = true,
+  className,
   ...rest
 }: FormikInputProps) => {
   const inputClassNames = classNames(
@@ -34,7 +35,7 @@ const FormikInput = ({
   );
   return (
     <>
-      <div>
+      <div className={className}>
         <Label name={label} displayTag={displayTag} info={info} className={'whitespace-nowrap'}>
           <Field
             type={type}

--- a/src/components/history/History.tsx
+++ b/src/components/history/History.tsx
@@ -371,9 +371,11 @@ export default function History(props: HistoryProps) {
               </div>
             )}
             {history.entries.length > 0 && (
-              <TopScrollingBar>
-                <DataTable columns={historyColumns} data={history.entries} fixedHeader={true} />
-              </TopScrollingBar>
+              <div className="mx-auto max-w-screen-xl">
+                <TopScrollingBar>
+                  <DataTable columns={historyColumns} data={history.entries} fixedHeader={true} />
+                </TopScrollingBar>
+              </div>
             )}
           </>
         ) : isValidInput ? (

--- a/src/components/labware/Labware.tsx
+++ b/src/components/labware/Labware.tsx
@@ -266,12 +266,12 @@ const Labware = ({
 
   const gridClasses = classNames(
     {
-      'px-12 gap-4': numColumns <= 3,
-      'px-10 gap-3': numColumns <= 5,
-      'px-6 gap-2': numColumns > 6
+      'px-12 gap-4 md:px-3 md:gap-1': numColumns <= 3,
+      'px-10 gap-3 md:px-2 md:gap-1': numColumns > 3 && numColumns <= 5,
+      'px-6 gap-2 md:px-1 md:gap-1': numColumns > 6
     },
 
-    `${grid} py-4 select-none`
+    `${grid} py-4 select-none md:py-1`
   );
 
   // Give slots some default styles if some haven't been passed in

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -334,7 +334,7 @@ function Search() {
             </Formik>
           </div>
 
-          <div className="my-10">
+          <div className="my-10 mx-auto max-w-screen-xl">
             {current.matches('searching') && (
               <div className="flex flex-row justify-center">
                 <LoadingSpinner />


### PR DESCRIPTION
- Refactor Xenium Analyser UI.
- Remove the use of useState in the Xenium Analyser page and rely fully on Formik functionalities. This improves performance and enhances readability by eliminating extra type definitions and ensuring that validation is handled solely through Formik.