### PR TITLE
support new labware for CyAssist operation

### DIFF
--- a/src/components/slotMapper/MultipleLabwareSlotMapper.tsx
+++ b/src/components/slotMapper/MultipleLabwareSlotMapper.tsx
@@ -145,7 +145,9 @@ const MultipleLabwareSlotMapper: React.FC<SlotMapperProps> = ({
   const { setFieldValue, values, setFieldError } = useFormikContext<CytAssistOutputLabwareForm>();
 
   const disabledOutputSlotAddresses = React.useMemo(() => {
-    return currentOutput?.labware && currentOutput?.labware.labwareType.name === LabwareTypeName.VISIUM_LP_CYTASSIST
+    return currentOutput?.labware &&
+      (currentOutput?.labware.labwareType.name === LabwareTypeName.VISIUM_LP_CYTASSIST ||
+        currentOutput?.labware.labwareType.name === LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_6_5)
       ? ['B1', 'C1']
       : [];
   }, [currentOutput]);
@@ -626,7 +628,10 @@ const MultipleLabwareSlotMapper: React.FC<SlotMapperProps> = ({
                 options={[
                   LabwareTypeName.VISIUM_LP_CYTASSIST,
                   LabwareTypeName.VISIUM_LP_CYTASSIST_XL,
-                  LabwareTypeName.VISIUM_LP_CYTASSIST_HD
+                  LabwareTypeName.VISIUM_LP_CYTASSIST_HD,
+                  LabwareTypeName.VISIUM_LP_CYTASSIST_HD_11,
+                  LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_6_5,
+                  LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_11
                 ].map((key) => {
                   return {
                     label: key,

--- a/src/lib/factories/labwareFactory.ts
+++ b/src/lib/factories/labwareFactory.ts
@@ -142,6 +142,17 @@ export const stripTubeFactory = unregisteredLabwareFactory.associations({
   labwareType: labwareTypes[LabwareTypeName.STRIP_TUBE].build()
 });
 
+export const visiumLPCytAssistHD11Factory = unregisteredLabwareFactory.associations({
+  labwareType: labwareTypes[LabwareTypeName.VISIUM_LP_CYTASSIST_HD_11].build()
+});
+
+export const visiumLPCytAssistHD365Factory = unregisteredLabwareFactory.associations({
+  labwareType: labwareTypes[LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_6_5].build()
+});
+
+export const visiumLPCytAssistHD311Factory = unregisteredLabwareFactory.associations({
+  labwareType: labwareTypes[LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_11].build()
+});
 export const labwareFactories: Record<LabwareTypeName, Factory<NewLabwareLayout>> = {
   [LabwareTypeName.TUBE]: tubeFactory,
   [LabwareTypeName.PROVIASETTE]: proviasetteFactory,
@@ -160,7 +171,10 @@ export const labwareFactories: Record<LabwareTypeName, Factory<NewLabwareLayout>
   [LabwareTypeName.VISIUM_LP_CYTASSIST_XL]: visiumLPCytAssistXLFactory,
   [LabwareTypeName.VISIUM_LP_CYTASSIST_HD]: visiumLPCytAssistHDFactory,
   [LabwareTypeName.XENIUM]: xeniumFactory,
-  [LabwareTypeName.STRIP_TUBE]: stripTubeFactory
+  [LabwareTypeName.STRIP_TUBE]: stripTubeFactory,
+  [LabwareTypeName.VISIUM_LP_CYTASSIST_HD_11]: visiumLPCytAssistHD11Factory,
+  [LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_6_5]: visiumLPCytAssistHD365Factory,
+  [LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_11]: visiumLPCytAssistHD311Factory
 };
 
 export const flaggedLabwareLayout = (labwareType: string) => {

--- a/src/lib/factories/labwareTypeFactory.ts
+++ b/src/lib/factories/labwareTypeFactory.ts
@@ -128,6 +128,27 @@ export const labwareTypes: Record<LabwareTypeName, Factory<LabwareType>> = {
     numColumns: 1,
     labelType: labelTypeFactory.build({ name: `${LabwareTypeName.VISIUM_LP_CYTASSIST_HD} Label` })
   }),
+  [LabwareTypeName.VISIUM_LP_CYTASSIST_HD_11]: labwareTypeFactory.params({
+    __typename: 'LabwareType',
+    name: LabwareTypeName.VISIUM_LP_CYTASSIST_HD_11,
+    numRows: 2,
+    numColumns: 1,
+    labelType: labelTypeFactory.build({ name: `${LabwareTypeName.VISIUM_LP_CYTASSIST_HD_11} Label` })
+  }),
+  [LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_6_5]: labwareTypeFactory.params({
+    __typename: 'LabwareType',
+    name: LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_6_5,
+    numRows: 4,
+    numColumns: 1,
+    labelType: labelTypeFactory.build({ name: `${LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_6_5} Label` })
+  }),
+  [LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_11]: labwareTypeFactory.params({
+    __typename: 'LabwareType',
+    name: LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_11,
+    numRows: 2,
+    numColumns: 1,
+    labelType: labelTypeFactory.build({ name: `${LabwareTypeName.VISIUM_LP_CYTASSIST_HD_3_11} Label` })
+  }),
   [LabwareTypeName.STRIP_TUBE]: labwareTypeFactory.params({
     __typename: 'LabwareType',
     name: LabwareTypeName.STRIP_TUBE,

--- a/src/types/stan.ts
+++ b/src/types/stan.ts
@@ -39,6 +39,9 @@ export enum LabwareTypeName {
   VISIUM_LP_CYTASSIST= "CytAssist 6.5 Visium LP",
   VISIUM_LP_CYTASSIST_XL= "CytAssist 11 Visium LP",
   VISIUM_LP_CYTASSIST_HD= "Visium LP CytAssist HD",
+  VISIUM_LP_CYTASSIST_HD_11= "CytAssist HD 11",
+  VISIUM_LP_CYTASSIST_HD_3_6_5= "CytAssist HD 3' 6.5",
+  VISIUM_LP_CYTASSIST_HD_3_11= "CytAssist HD 3' 11",
   XENIUM = "Xenium",
   STRIP_TUBE = "8 Strip Tube"
 


### PR DESCRIPTION
New labware types:
CytAssist HD 11 - slots A1 B1
CytAssist HD 3' 6.5 - slots A1 D1
CytAssist HD 3' 11 - slots A1 B1