### PR TITLE
add more stain types

### DIFF
--- a/src/mocks/repositories/stainTypeRepository.ts
+++ b/src/mocks/repositories/stainTypeRepository.ts
@@ -7,6 +7,18 @@ const stainTypeSeeds: Array<StainTypeFieldsFragment> = [
     name: 'H&E',
     measurementTypes: ['Haematoxylin', 'Blueing', 'Eosin']
   }),
+  stainTypeFactory.build({
+    name: 'H&E CytAssist',
+    measurementTypes: ['Haematoxylin', 'Blueing', 'Eosin']
+  }),
+  stainTypeFactory.build({
+    name: 'H&E Post Xenium',
+    measurementTypes: ['Haematoxylin', 'Blueing', 'Eosin']
+  }),
+  stainTypeFactory.build({
+    name: 'H&E QC',
+    measurementTypes: ['Haematoxylin', 'Blueing', 'Eosin']
+  }),
   stainTypeFactory.build({ name: "Masson's Trichrome" }),
   stainTypeFactory.build({ name: 'RNAscope' }),
   stainTypeFactory.build({ name: 'IHC' })


### PR DESCRIPTION
the client does not really require changes to add stain types, as it gets the types from the core. This is mainly to make the mocking server confirm to the real data.