### PR TITLE
x1500 - [PR] As ARA (Jasmine) I would like to add to the warning messages that appears at the cytassist operation if the probe hyb cytassist and probe hyb qc haven't been performed for labware

### DIFF
--- a/cypress/e2e/pages/cytAssist.cy.ts
+++ b/cypress/e2e/pages/cytAssist.cy.ts
@@ -60,12 +60,8 @@ describe('CytAssist Page', () => {
     it('should display a warning message', () => {
       cy.contains(
         '.Toastify__toast-body',
-        "No 'Probe hybridisation Cytassist' operation has been recorded for labware STAN-3100. (not required for 3')"
-      ).should('be.visible');
-      cy.contains(
-        '.Toastify__toast-body',
-        "No 'Probe hybridisation QC' operation has been recorded for labware STAN-3100. (not required for 3')"
-      ).should('be.visible');
+        "Labware STAN-3100 is missing the following operations (not required for 3'): 'Probe hybridisation Cytassist' , 'Probe hybridisation QC'"
+      );
     });
     after(() => {
       cy.findByTestId('removeButton').click();

--- a/src/components/slotMapper/MultipleLabwareSlotMapper.tsx
+++ b/src/components/slotMapper/MultipleLabwareSlotMapper.tsx
@@ -502,21 +502,18 @@ const MultipleLabwareSlotMapper: React.FC<SlotMapperProps> = ({
   const [warningMessage, setWarningMessage] = useState<string | undefined>(undefined);
 
   const areProbHybOpsPerformed = React.useCallback(async (barcode: string) => {
-    const warningMessages: string[] = [];
-    const isProbeHybCytAssistPerformed = await doesOpExistForLabware(barcode, 'Probe hybridisation Cytassist');
-    if (!isProbeHybCytAssistPerformed) {
-      warningMessages.push(
-        `No 'Probe hybridisation Cytassist' operation has been recorded for labware ${barcode}. (not required for 3')`
-      );
+    // List of required operations
+    const requiredOps = ['Probe hybridisation Cytassist', 'Probe hybridisation QC'];
+    const missingOps: string[] = [];
+    for (const op of requiredOps) {
+      if (!(await doesOpExistForLabware(barcode, op))) {
+        missingOps.push(`'${op}'`); // single quoted
+      }
     }
-    const isProbeHybQcPerformed = await doesOpExistForLabware(barcode, 'Probe hybridisation QC');
-    if (!isProbeHybQcPerformed) {
-      warningMessages.push(
-        `No 'Probe hybridisation QC' operation has been recorded for labware ${barcode}. (not required for 3')`
+    if (missingOps.length > 0) {
+      setWarningMessage(
+        `Labware ${barcode} is missing the following operations (not required for 3'): ${missingOps.join(' , ')}`
       );
-    }
-    if (warningMessages.length > 0) {
-      setWarningMessage(warningMessages.join('\n'));
     } else {
       setWarningMessage(undefined);
     }


### PR DESCRIPTION
Closes #

#### Changes proposed in this pull request

- Add text (not required for 3') and update warning message. Example:
```
Labware STAN-0001F is missing the following operations (not
required for 3'): 'Probe hybridisation Cytassist', 'Probe
hybridisation QC'
```

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
