### PR TITLE
Sectioning planning page freezing

### DIFF
--- a/src/components/planning/LabwarePlan.tsx
+++ b/src/components/planning/LabwarePlan.tsx
@@ -385,6 +385,7 @@ const LabwarePlan = React.forwardRef<HTMLDivElement, LabwarePlanProps>(
                             'plannedActions',
                             layoutMachine.getSnapshot().context.layoutPlan.plannedActions
                           );
+                          await validateForm();
                         }
                       }}
                       className="w-full text-base sm:ml-3 sm:w-auto sm:text-sm"


### PR DESCRIPTION
The sectioning plan was not assigned to the form when the user left the sectioning step until the last stage (after entering the barcodes). As a result, the form failed validation silently, which explains the page freeze.
